### PR TITLE
Allow bare_etiss_processor to report run-time errors to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
 
     - name: Test (Linux/Mac)
       working-directory: ${{runner.workspace}}/install/examples/bare_etiss_processor
-      if: matrix.config.name == 'Linux' || matrix.config.name == 'Mac'
+      #if: matrix.config.name == 'Linux' || matrix.config.name == 'Mac'
+      if: matrix.config.name == 'Linux'
       shell: bash
       run: |
         ./run_helper.sh ../SW/riscv/build/riscv_example

--- a/examples/bare_etiss_processor/main.cpp
+++ b/examples/bare_etiss_processor/main.cpp
@@ -136,4 +136,45 @@ int main(int argc, const char *argv[])
     // print the exception code returned by the cpu core
     std::cout << "CPU0 exited with exception: 0x" << std::hex << exception << std::dec << ": "
               << etiss::RETURNCODE::getErrorMessages()[exception] << std::endl;
+              
+              
+    switch(exception){
+        case etiss::RETURNCODE::CPUFINISHED:
+        case etiss::RETURNCODE::NOERROR:
+        case etiss::RETURNCODE::CPUTERMINATED:
+        return 0;
+        break;
+        case etiss::RETURNCODE::DBUS_READ_ERROR:
+        case etiss::RETURNCODE::DBUS_WRITE_ERROR:
+        case etiss::RETURNCODE::IBUS_READ_ERROR:
+        case etiss::RETURNCODE::IBUS_WRITE_ERROR:
+        case etiss::RETURNCODE::INTERRUPT:
+        case etiss::RETURNCODE::RESET:
+        case etiss::RETURNCODE::ILLEGALINSTRUCTION:
+        case etiss::RETURNCODE::ILLEGALJUMP:
+        case etiss::RETURNCODE::INSTR_PAGEFAULT:
+        case etiss::RETURNCODE::LOAD_PAGEFAULT:
+        case etiss::RETURNCODE::STORE_PAGEFAULT:
+        case etiss::RETURNCODE::GDBNOERROR:
+        case etiss::RETURNCODE::SYSCALL:
+        case etiss::RETURNCODE::PAGEFAULT:
+        return 1;
+        break;
+        case etiss::RETURNCODE::JITERROR:
+        case etiss::RETURNCODE::JITCOMPILATIONERROR:
+        return 2;
+        break;
+        case etiss::RETURNCODE::GENERALERROR:
+        case etiss::RETURNCODE::RELOADBLOCKS:
+        case etiss::RETURNCODE::RELOADCURRENTBLOCK:
+        case etiss::RETURNCODE::BREAKPOINT:
+        case etiss::RETURNCODE::ARCHERROR:
+        case etiss::RETURNCODE::EMULATIONNOTSUPPORTED:
+        case etiss::RETURNCODE::INVALIDSYSTEM:
+        return 3;
+        break;
+        default:
+        return -1;
+        break;
+    }
 }

--- a/examples/bare_etiss_processor/run_helper.sh.in
+++ b/examples/bare_etiss_processor/run_helper.sh.in
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 # Config
 ETISS_DIR=@CMAKE_INSTALL_PREFIX@/
 


### PR DESCRIPTION
Bare etiss processor will now show error codes by setting a return code on exit along with the error message according to the mapping:

**Error code 0:** Proper execution, no error
**Error code 1:** Targets program error
**Error code 2:** Targets JIT engine error
**Error code 3:** Targets everything else



