### PR TITLE
enable all RISC-V interrupts by default 

### DIFF
--- a/ArchImpl/RISCV/RISCVArch.cpp
+++ b/ArchImpl/RISCV/RISCVArch.cpp
@@ -174,6 +174,15 @@ void RISCVArch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
 		riscvcpu->FENCE[i] = 0;
 	}
 	riscvcpu->RES = 0;
+
+	/* >>> manually added code section */
+	riscvcpu->CSR[0x304] = (0xFFFFFBBB);
+		// MIE: enable all core-local and add. platform-specific interrupts
+	riscvcpu->CSR[0x104] = riscvcpu->CSR[0x304] & (~(0x888));
+		// SIE: enable all core-local and add. platform-specific interrupts (supervised)
+	riscvcpu->CSR[0x004] = riscvcpu->CSR[0x304] & (~(0xAAA));
+		// UIE: enable all core-local and add. platform-specific interrupts (user)
+	/* <<< manually added code section */
 }
 
 void RISCVArch::deleteCPU(ETISS_CPU *cpu)

--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -180,6 +180,15 @@ void RISCV64Arch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
 		riscv64cpu->FENCE[i] = 0;
 	}
 	riscv64cpu->RES = 0;
+
+	/* >>> manually added code section */
+	riscv64cpu->CSR[0x304] = (0xFFFFFFFFFFFFFBBB);
+		// MIE: enable all core-local and add. platform-specific interrupts
+	riscv64cpu->CSR[0x104] = riscv64cpu->CSR[0x304] & (~(0x888));
+		// SIE: enable all core-local and add. platform-specific interrupts (supervised)
+	riscv64cpu->CSR[0x004] = riscv64cpu->CSR[0x304] & (~(0xAAA));
+		// UIE: enable all core-local and add. platform-specific interrupts (user)
+	/* <<< manually added code section */
 }
 
 void RISCV64Arch::deleteCPU(ETISS_CPU *cpu)


### PR DESCRIPTION
(2nd attempt w/ trailing whitespace issue in staged files)

workaround for #29

core-local [11:0], platform-specific [XLEN-1:12]