### PR TITLE
bare_etiss_processor: replace hardcoded memory properties

### DIFF
--- a/examples/bare_etiss_processor/CMakeLists.txt.in
+++ b/examples/bare_etiss_processor/CMakeLists.txt.in
@@ -22,3 +22,27 @@ add_executable(main main.cpp)
 #link required libraries
 #not python libraries may not be found and this could lead to problems if ETISS was configure to use python.
 target_link_libraries(main ${ETISS_LIBRARIES})
+
+IF(PULPINO_ROM_START)
+    add_compile_definitions(ROM_START=${PULPINO_ROM_START})
+ELSE()
+    add_compile_definitions(ROM_START=0x0)
+ENDIF()
+
+IF(PULPINO_ROM_SIZE)
+    add_compile_definitions(ROM_SIZE=${PULPINO_ROM_SIZE})
+ELSE()
+    add_compile_definitions(ROM_SIZE=0x80000)
+ENDIF()
+
+IF(PULPINO_RAM_START)
+    add_compile_definitions(RAM_START=${PULPINO_RAM_START})
+ELSE()
+    add_compile_definitions(RAM_START=0x80000)
+ENDIF()
+
+IF(PULPINO_RAM_SIZE)
+    add_compile_definitions(RAM_SIZE=${PULPINO_RAM_SIZE})
+ELSE()
+    add_compile_definitions(RAM_SIZE=0x80000)
+ENDIF()

--- a/examples/bare_etiss_processor/get_metrics.py
+++ b/examples/bare_etiss_processor/get_metrics.py
@@ -21,11 +21,6 @@ Then run this script:
 '''
 
 
-RAM_START = 0x100000
-RAM_SIZE = 0x100000
-STACK_SIZE = 0x4000
-
-
 class MemRange:
     def __init__(self, name, min, max):
         self.name = name
@@ -71,6 +66,9 @@ def parseElf(inFile):
     with open(inFile, "rb") as f:
         e = elffile.ELFFile(f)
 
+        ramStart = e.get_segment(1)['p_paddr']
+        ramSize = e.get_segment(1)['p_memsz']
+
         for s in e.iter_sections():
             if s.name.startswith(".text"):
                 m["rom_code"] += s.data_size
@@ -99,10 +97,12 @@ def parseElf(inFile):
                 for sym in s.iter_symbols():
                     if sym.name == "_heap_start":
                         heapStart = sym["st_value"]
+                    elif sym.name == "_min_stack":
+                        stackSize = sym["st_value"]
             else:
                 print("warning: ignored: " + s.name + " / size: " + str(s.data_size))
 
-    return m, heapStart
+    return m, ramStart, ramSize, heapStart, stackSize
 
 
 def printSz(sz):
@@ -115,15 +115,15 @@ if __name__ == "__main__":
         exit(1)
 
     elfFile = sys.argv[1]
-    staticSizes, heapStart = parseElf(elfFile)
+    staticSizes, ramStart, ramSize, heapStart, stackSize = parseElf(elfFile)
     if not heapStart:
         raise RuntimeError("did not find heap start")
 
     print("heap starts at: " + hex(heapStart))
 
-    d = MemRange("Data", RAM_START, heapStart)
-    h = MemRange("Heap", heapStart, RAM_START + RAM_SIZE - STACK_SIZE)
-    s = MemRange("Stack", RAM_START + RAM_SIZE - STACK_SIZE, RAM_START + RAM_SIZE)
+    d = MemRange("Data", ramStart, heapStart)
+    h = MemRange("Heap", heapStart, ramStart + ramSize - stackSize)
+    s = MemRange("Stack", ramStart + ramSize - stackSize, ramStart + ramSize)
     mems = [d, h, s]
 
     traceFile = sys.argv[2] if len(sys.argv) > 2 else "dBusAccess.csv"

--- a/examples/bare_etiss_processor/main.cpp
+++ b/examples/bare_etiss_processor/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, const char *argv[])
     std::cout << "=== Setting up test system ===" << std::endl;
     std::cout << "  Setting up Memory" << std::endl;
 
-    etiss::SimpleMemSystem dsys(0x0, 0x80000, 0x80000, 0x80000);
+    etiss::SimpleMemSystem dsys(ROM_START, ROM_SIZE, RAM_START, RAM_SIZE);
     if (dsys.load_elf(etiss::cfg().get<std::string>("vp.elf_file", "").c_str() ) < 0 ){
       etiss::log(etiss::FATALERROR, "ELF file not loaded properly\n");
     }


### PR DESCRIPTION
1. `get_metrics.py` determines `RAM_START`, `RAM_SIZE` and `STACK_SIZE` by parsing the ELF file instead of using constants
2. `main.cpp` uses the pre-processor variables `ROM_START`, `ROM_SIZE`, `RAM_START` and `RAM_SIZE` instead of hardcoded `0x0`, `0x80000`, `0x80000`, `0x80000` which can be overwrite with  CMake variables when building `bare_etiss_processor`.

This allows to change the aforementioned properties without needing to patch files manually and also ensures that the exported memory reports are based on the actual values.