### PR TITLE
Fix CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,9 @@ jobs:
       run: |
         PATH=$PATH:/d/a/etiss/install/lib/
         cd $BUILD_TYPE
-        ./main.exe --vp.elf_file=../../../SW/riscv/build/riscv_example.elf --arch.cpu=RISCV --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
-        ./main.exe --vp.elf_file=../../../SW/riscv/build/riscv_example.elf --arch.cpu=RISCV --jit.type=LLVMJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
-        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build/riscv_example.elf --arch.cpu=RISCV --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger
-        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build/riscv_example.elf --arch.cpu=RISCV --jit.type=LLVMJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger
-        ./main.exe --vp.elf_file=../../../SW/riscv/build64/riscv_example.elf --arch.cpu=RISCV --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
-        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build64/riscv_example.elf --arch.cpu=RISCV --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv/build/riscv_example.elf --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv/build/riscv_example.elf --jit.type=LLVMJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build/riscv_example.elf --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build/riscv_example.elf --jit.type=LLVMJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv/build64/riscv_example.elf --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv/memsegs.ini -pLogger
+        ./main.exe --vp.elf_file=../../../SW/riscv_cpp/build64/riscv_example.elf --jit.type=TCCJIT --etiss.loglevel=4 -i../../../SW/riscv_cpp/memsegs.ini -pLogger

--- a/JITImpl/TCC/TCCJIT.cpp
+++ b/JITImpl/TCC/TCCJIT.cpp
@@ -102,6 +102,8 @@ TCCJIT::TCCJIT() : JIT("tcc")
 {
 #if ETISS_USE_GETPROC
     addAllSymbols(extsymbols);
+    for (const auto &jitPath : etiss::jitExtLibPaths())
+        etiss::LibraryInterface::AddSearchPath(jitPath);
 #endif
 }
 

--- a/JITImpl/TCC/TCCJIT.cpp
+++ b/JITImpl/TCC/TCCJIT.cpp
@@ -102,8 +102,6 @@ TCCJIT::TCCJIT() : JIT("tcc")
 {
 #if ETISS_USE_GETPROC
     addAllSymbols(extsymbols);
-    for (const auto &jitPath : etiss::jitExtLibPaths())
-        etiss::LibraryInterface::AddSearchPath(jitPath);
 #endif
 }
 
@@ -143,6 +141,8 @@ void *TCCJIT::translate(std::string code, std::set<std::string> headerpaths, std
     {
         tcc_add_symbol(s, sym.first.c_str(), sym.second);
     }
+    for (const auto &jitPath : etiss::jitExtLibPaths())
+        etiss::LibraryInterface::AddSearchPath(etiss::jitFiles() + jitPath);
 #endif
 
     // init libs

--- a/JITImpl/TCC/TCCJIT.cpp
+++ b/JITImpl/TCC/TCCJIT.cpp
@@ -142,7 +142,9 @@ void *TCCJIT::translate(std::string code, std::set<std::string> headerpaths, std
         tcc_add_symbol(s, sym.first.c_str(), sym.second);
     }
     for (const auto &jitPath : etiss::jitExtLibPaths())
-        etiss::LibraryInterface::AddSearchPath(etiss::jitFiles() + jitPath);
+    {
+        etiss::LibraryInterface::addSearchPath(etiss::jitFiles() + jitPath);
+    }
 #endif
 
     // init libs

--- a/include/etiss/LibraryInterface.h
+++ b/include/etiss/LibraryInterface.h
@@ -141,7 +141,7 @@ class LibraryInterface
 
     static unsigned getCurrentLibraryVersion();
 
-    static void AddSearchPath(const std::string &path);
+    static void addSearchPath(const std::string &path);
 
   private:
     std::string name_;

--- a/include/etiss/LibraryInterface.h
+++ b/include/etiss/LibraryInterface.h
@@ -141,6 +141,8 @@ class LibraryInterface
 
     static unsigned getCurrentLibraryVersion();
 
+    static void AddSearchPath(const std::string &path);
+
   private:
     std::string name_;
 };

--- a/src/LibraryInterface.cpp
+++ b/src/LibraryInterface.cpp
@@ -603,7 +603,7 @@ std::shared_ptr<LibraryInterface> LibraryInterface::openSharedLibrary(std::strin
 }
 
 
-void LibraryInterface::AddSearchPath(const std::string &path)
+void LibraryInterface::addSearchPath(const std::string &path)
 {
 #if ETISS_USE_GETPROC
     int len = (int)path.length() + 1;

--- a/src/LibraryInterface.cpp
+++ b/src/LibraryInterface.cpp
@@ -601,3 +601,17 @@ std::shared_ptr<LibraryInterface> LibraryInterface::openSharedLibrary(std::strin
     return nullptr;
 #endif
 }
+
+
+void LibraryInterface::AddSearchPath(const std::string &path)
+{
+#if ETISS_USE_GETPROC
+    int len = (int)path.length() + 1;
+    int newlen = MultiByteToWideChar(CP_ACP, 0, path.c_str(), len, 0, 0);
+    std::vector<wchar_t> buf(newlen);
+    MultiByteToWideChar(CP_ACP, 0, path.c_str(), len, buf.data(), newlen);
+
+    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    AddDllDirectory(buf.data());
+#endif
+}

--- a/src/Translation.cpp
+++ b/src/Translation.cpp
@@ -366,14 +366,6 @@ BlockLink *Translation::getBlock(BlockLink *prev, const etiss::uint64 &instructi
        if(it != "") libloc.insert(etiss::jitFiles() + it);
     }
 
-    static bool once = true;
-    if (once) {
-        once = false;
-        for (auto& it : libloc) {
-            printf("LIBLOC: %s\n", it.c_str());
-        }
-    }
-
     std::set<std::string> libs;
     //libs.insert("ETISS");
     libs.insert("resources");

--- a/src/Translation.cpp
+++ b/src/Translation.cpp
@@ -366,6 +366,14 @@ BlockLink *Translation::getBlock(BlockLink *prev, const etiss::uint64 &instructi
        if(it != "") libloc.insert(etiss::jitFiles() + it);
     }
 
+    static bool once = true;
+    if (once) {
+        once = false;
+        for (auto& it : libloc) {
+            printf("LIBLOC: %s\n", it.c_str());
+        }
+    }
+
     std::set<std::string> libs;
     //libs.insert("ETISS");
     libs.insert("resources");


### PR DESCRIPTION
This wouldn't really have to be in the translate function, but the constructor is too early to have the library path additions from the Arch plugins.