### PR TITLE
Update README.md with correct RISCV_ARCH (-march) flag

### DIFF
--- a/examples/SW/riscv/README.md
+++ b/examples/SW/riscv/README.md
@@ -28,7 +28,7 @@ To compile the SW:
   ## LINUX SYSTEM
 	$ cmake -DRISCV_ELF_GCC_PREFIX=path/to/toolchain -DRISCV_ELF_GCC_BASENAME=riscv64-unknown-elf ..
 	# for RV64...
-	$ cmake -DRISCV_ELF_GCC_PREFIX=path/to/toolchain -DRISCV_ELF_GCC_BASENAME=riscv64-unknown-elf -DRISCV_ARCH=rv64g -DRISCV_ABI=lp64d ..
+	$ cmake -DRISCV_ELF_GCC_PREFIX=path/to/toolchain -DRISCV_ELF_GCC_BASENAME=riscv64-unknown-elf -DRISCV_ARCH=rv64gc -DRISCV_ABI=lp64d ..
 	
 	$ make
 


### PR DESCRIPTION
The recommend [toolchain](https://www.sifive.com/software) (`v2020.12.8`) does not seem to support `rv64g`. Only `rv64gc` (i.e. `rv64imfdc`) is supported. 

Invoking `cmake [...] -DRISCV_ARCH=rv64g -DRISCV_ABI=lp64d ..` and then `make` results in: 

```
/home/fabian/master/fp/toolchains/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin/../lib/gcc/riscv64-unknown-elf/10.2.0/../../../../riscv64-unknown-elf/bin/ld: cannot find -lstdc++
collect2: error: ld returned 1 exit status
```
for me. 

Running `cmake [...] -DRISCV_ARCH=rv64gc -DRISCV_ABI=lp64d ..` and then `make` instead gives no errors.

Running `./riscv64-unknown-elf-gcc --print-multi-lib` gives:

```
.;
rv32ec/ilp32e;@march=rv32ec@mabi=ilp32e
rv32ec_zba_zbb/ilp32e;@march=rv32ec_zba_zbb@mabi=ilp32e
rv32eac/ilp32e;@march=rv32eac@mabi=ilp32e
rv32eac_zba_zbb/ilp32e;@march=rv32eac_zba_zbb@mabi=ilp32e
rv32emc/ilp32e;@march=rv32emc@mabi=ilp32e
rv32emc_zba_zbb/ilp32e;@march=rv32emc_zba_zbb@mabi=ilp32e
rv32emac/ilp32e;@march=rv32emac@mabi=ilp32e
rv32emac_zba_zbb/ilp32e;@march=rv32emac_zba_zbb@mabi=ilp32e
rv32ic/ilp32;@march=rv32ic@mabi=ilp32
rv32ic_zba_zbb/ilp32;@march=rv32ic_zba_zbb@mabi=ilp32
rv32iac/ilp32;@march=rv32iac@mabi=ilp32
rv32iac_zba_zbb/ilp32;@march=rv32iac_zba_zbb@mabi=ilp32
rv32imc/ilp32;@march=rv32imc@mabi=ilp32
rv32imc_zba_zbb/ilp32;@march=rv32imc_zba_zbb@mabi=ilp32
rv32imac/ilp32;@march=rv32imac@mabi=ilp32
rv32imac_zba_zbb/ilp32;@march=rv32imac_zba_zbb@mabi=ilp32
rv32imfc/ilp32f;@march=rv32imfc@mabi=ilp32f
rv32imfc_zba_zbb/ilp32f;@march=rv32imfc_zba_zbb@mabi=ilp32f
rv32imafc/ilp32f;@march=rv32imafc@mabi=ilp32f
rv32imafc_zba_zbb/ilp32f;@march=rv32imafc_zba_zbb@mabi=ilp32f
rv32imfdc/ilp32d;@march=rv32imfdc@mabi=ilp32d
rv32imfdc_zba_zbb/ilp32d;@march=rv32imfdc_zba_zbb@mabi=ilp32d
rv32imafdc/ilp32d;@march=rv32imafdc@mabi=ilp32d
rv32imafdc_zba_zbb/ilp32d;@march=rv32imafdc_zba_zbb@mabi=ilp32d
rv64ic/lp64;@march=rv64ic@mabi=lp64
rv64ic/lp64/compact;@march=rv64ic@mabi=lp64@mcmodel=compact
rv64ic_zba_zbb/lp64;@march=rv64ic_zba_zbb@mabi=lp64
rv64ic_zba_zbb/lp64/compact;@march=rv64ic_zba_zbb@mabi=lp64@mcmodel=compact
rv64iac/lp64;@march=rv64iac@mabi=lp64
rv64iac/lp64/compact;@march=rv64iac@mabi=lp64@mcmodel=compact
rv64iac_zba_zbb/lp64;@march=rv64iac_zba_zbb@mabi=lp64
rv64iac_zba_zbb/lp64/compact;@march=rv64iac_zba_zbb@mabi=lp64@mcmodel=compact
rv64imc/lp64;@march=rv64imc@mabi=lp64
rv64imc/lp64/compact;@march=rv64imc@mabi=lp64@mcmodel=compact
rv64imc_zba_zbb/lp64;@march=rv64imc_zba_zbb@mabi=lp64
rv64imc_zba_zbb/lp64/compact;@march=rv64imc_zba_zbb@mabi=lp64@mcmodel=compact
rv64imac/lp64;@march=rv64imac@mabi=lp64
rv64imac/lp64/compact;@march=rv64imac@mabi=lp64@mcmodel=compact
rv64imac_zba_zbb/lp64;@march=rv64imac_zba_zbb@mabi=lp64
rv64imac_zba_zbb/lp64/compact;@march=rv64imac_zba_zbb@mabi=lp64@mcmodel=compact
rv64imfc/lp64f;@march=rv64imfc@mabi=lp64f
rv64imfc/lp64f/compact;@march=rv64imfc@mabi=lp64f@mcmodel=compact
rv64imfc_zba_zbb/lp64f;@march=rv64imfc_zba_zbb@mabi=lp64f
rv64imfc_zba_zbb/lp64f/compact;@march=rv64imfc_zba_zbb@mabi=lp64f@mcmodel=compact
rv64imafc/lp64f;@march=rv64imafc@mabi=lp64f
rv64imafc/lp64f/compact;@march=rv64imafc@mabi=lp64f@mcmodel=compact
rv64imafc_zba_zbb/lp64f;@march=rv64imafc_zba_zbb@mabi=lp64f
rv64imafc_zba_zbb/lp64f/compact;@march=rv64imafc_zba_zbb@mabi=lp64f@mcmodel=compact
rv64imfdc/lp64d;@march=rv64imfdc@mabi=lp64d
rv64imfdc/lp64d/compact;@march=rv64imfdc@mabi=lp64d@mcmodel=compact
rv64imfdc_zba_zbb/lp64d;@march=rv64imfdc_zba_zbb@mabi=lp64d
rv64imfdc_zba_zbb/lp64d/compact;@march=rv64imfdc_zba_zbb@mabi=lp64d@mcmodel=compact
rv64imafdc/lp64d;@march=rv64imafdc@mabi=lp64d
rv64imafdc/lp64d/compact;@march=rv64imafdc@mabi=lp64d@mcmodel=compact
rv64imafdc_zba_zbb/lp64d;@march=rv64imafdc_zba_zbb@mabi=lp64d
rv64imafdc_zba_zbb/lp64d/compact;@march=rv64imafdc_zba_zbb@mabi=lp64d@mcmodel=compact
```
which supports this claim. 

Sources:
https://github.com/riscv/riscv-gnu-toolchain/issues/669
https://github.com/sifive/riscv-llvm/issues/10
