### PR TITLE
Improve get_metrics.py

### DIFF
--- a/examples/bare_etiss_processor/requirements.txt
+++ b/examples/bare_etiss_processor/requirements.txt
@@ -1,2 +1,3 @@
 humanize
 elftools
+argparse

--- a/examples/bare_etiss_processor/requirements.txt
+++ b/examples/bare_etiss_processor/requirements.txt
@@ -1,0 +1,2 @@
+humanize
+elftools


### PR DESCRIPTION
I have implemented what was beeing discussed in #68 in addition with further smaller improvements to the `get_metrics.py` script.

I had to add the argparse package as a requirement to be able to use optional command line parameters. This should hopefully not break too many existing setups...

For parsing the INI containing the memory layout, I have used the following as a reference. Can I expect that there are always 2 memory segments, the first being for ROM and the other one for RAM? If not, then I am not sure how to find out which one is which...

```
$ cat memsegs.ini
# [IntConfigurations]
# simple_mem_system.memseg_origin_00=0x0
# simple_mem_system.memseg_length_00=0x100000
# simple_mem_system.memseg_origin_01=0x100000
# simple_mem_system.memseg_length_01=0x5000000 
```

BTW: `heapStart` is unfortunately still relying on the symbol table.