### PR TITLE
Fix RISC-V MISA CSR contents

### DIFF
--- a/ArchImpl/RISCV/RISCVArch.cpp
+++ b/ArchImpl/RISCV/RISCVArch.cpp
@@ -168,7 +168,7 @@ void RISCVArch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
 	riscvcpu->CSR[256] = 15;								
 	riscvcpu->CSR[768] = 15;								
 	riscvcpu->CSR[260] = 4294967295;								
-	riscvcpu->CSR[769] = 1315077;								
+	riscvcpu->CSR[769] = 0x4014112D;
 	riscvcpu->CSR[3088] = 3;								
 	for (int i = 0; i<4 ;i++){
 		riscvcpu->FENCE[i] = 0;

--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -174,7 +174,7 @@ void RISCV64Arch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
 	riscv64cpu->CSR[256] = 15;								
 	riscv64cpu->CSR[768] = 15;								
 	riscv64cpu->CSR[260] = 4294967295;								
-	riscv64cpu->CSR[769] = 1315077;								
+	riscv64cpu->CSR[769] = 0x800000000014112D;
 	riscv64cpu->CSR[3088] = 3;								
 	for (int i = 0; i<4 ;i++){
 		riscv64cpu->FENCE[i] = 0;


### PR DESCRIPTION
The MISA CSR is currently missing the MXL field (Machine XLEN) and the
F/D extensions. Add both for RV32 and RV64.

With this change, OpenSBI runs on ETISS.