### PR TITLE
Support writing data at offsets within a memory segment

### DIFF
--- a/include/etiss/SimpleMemSystem.h
+++ b/include/etiss/SimpleMemSystem.h
@@ -109,11 +109,11 @@ class MemSegment
             delete[] mem_;
     }
 
-    void load(const void *data, size_t file_size_bytes)
+    void load(const void *data, size_t offset, size_t file_size_bytes)
     {
-        if (data != nullptr && file_size_bytes <= size_)
+        if (data != nullptr && (offset + file_size_bytes) <= size_)
         {
-            memcpy(mem_, data, file_size_bytes);
+            memcpy(mem_ + offset, data, file_size_bytes);
         }
     }
 

--- a/src/SimpleMemSystem.cpp
+++ b/src/SimpleMemSystem.cpp
@@ -231,7 +231,7 @@ void SimpleMemSystem::load_elf()
             mseg->name_ = sname.str();
             mseg->mode_ = static_cast<MemSegment::access_t>(mode);
 
-            mseg->load(seg->get_data() + (mseg->start_addr_ - start_addr), file_size);
+            mseg->load(seg->get_data(), start_addr - mseg->start_addr_, file_size);
 
             std::stringstream msg;
             msg << "Initialized the memory segment " << mseg->name_ << " from ELF-file";
@@ -265,7 +265,7 @@ void SimpleMemSystem::add_memsegment(std::unique_ptr<MemSegment>& mseg, const vo
     msg << "New Memory segment added: " << mseg->name_;
     etiss::log(etiss::INFO, msg.str().c_str());
 
-    mseg->load(raw_data, file_size_bytes);
+    mseg->load(raw_data, 0, file_size_bytes);
 
     msegs_.push_back(std::move(mseg));
 }


### PR DESCRIPTION
This is required to load multiple segments of an ELF file into a single memory segment.

I am not too familiar with the code base, please check if anything else has to be updated. I did test the changes locally with RISC-V.