### PR TITLE
RISCV/RISCV64: Initialize cpuCycleTime_ps with arch.cpu_cycle_time_ps INI option

### DIFF
--- a/ArchImpl/RISCV/RISCVArch.cpp
+++ b/ArchImpl/RISCV/RISCVArch.cpp
@@ -67,7 +67,8 @@ void RISCVArch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
     else cpu->instructionPointer = 0x0;   //  reference to manual
     cpu->mode = 1;
     cpu->cpuTime_ps = 0;
-    cpu->cpuCycleTime_ps = 31250;
+    cpu->cpuCycleTime_ps = etiss::cfg(getLastAssignedCoreName())
+                                 .get<uint32_t>("arch.cpu_cycle_time_ps", 31250); // original: 31250; // 32MHz
     #if RISCV_Pipeline1 || RISCV_Pipeline2
     //Initialize resources measurements
     cpu->resources[0] = "I_RAM";

--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -73,7 +73,8 @@ void RISCV64Arch::resetCPU(ETISS_CPU * cpu,etiss::uint64 * startpointer)
     else cpu->instructionPointer = 0x0;   //  reference to manual
     cpu->mode = 1;
     cpu->cpuTime_ps = 0;
-    cpu->cpuCycleTime_ps = 31250;
+    cpu->cpuCycleTime_ps = etiss::cfg(getLastAssignedCoreName())
+                                 .get<uint32_t>("arch.cpu_cycle_time_ps", 31250); // original: 31250; // 32MHz
     #if RISCV64_Pipeline1 || RISCV64_Pipeline2
     //Initialize resources measurements
     cpu->resources[0] = "I_RAM";

--- a/examples/bare_etiss_processor/ETISS.ini
+++ b/examples/bare_etiss_processor/ETISS.ini
@@ -122,9 +122,9 @@
 
   ; Set CPU freuquency in pico seconds
   ; (or1k)   default=10000
-  ; (ARMv6M) default=31250
+  ; (RISCV)  default=31250
 
-  arch.cpu_cycle_time_ps=10000
+  arch.cpu_cycle_time_ps=31250
 
   ; Set the memory configuration of bare_etiss_processor
   ; Up to 99 segments are supported

--- a/examples/bare_etiss_processor/base.ini
+++ b/examples/bare_etiss_processor/base.ini
@@ -16,7 +16,7 @@ testing = false
 
 arch.or1k.if_stall_cycles=0
 etiss.max_block_size=100
-arch.cpu_cycle_time_ps=10000
+arch.cpu_cycle_time_ps=31250
 ETISS::CPU_quantum_ps=100000
 ETISS::write_pc_trace_from_time_us=0
 ETISS::write_pc_trace_until_time_us=3000000


### PR DESCRIPTION
Resolves Issue #98

Default/Fallback value: 32MHZ as this was used before. However `base.ini` and `ETISS.ini` currently default to 100MHz.