### PR TITLE
add SelectiveSysWrapper and MemMappedPeriph

### DIFF
--- a/include/etiss/CPUCore.h
+++ b/include/etiss/CPUCore.h
@@ -323,6 +323,11 @@ class CPUCore : public VirtualStructSupport, public etiss::ToString
     }
 
     /**
+     * @brief Get a reference to the JIT plugin.
+     */
+    inline std::shared_ptr<etiss::JIT> getJIT() { return jit_; }
+
+    /**
      * @brief Get a string representation of the object.
      */
     inline const std::string &toString() const { return name_; }

--- a/include/etiss/IntegratedLibrary/Logger.h
+++ b/include/etiss/IntegratedLibrary/Logger.h
@@ -44,6 +44,7 @@
 #define ETISS_PLUGIN_LOGGER_H_
 
 #include "etiss/Plugin.h"
+#include "etiss/IntegratedLibrary/SelectiveSysWrapper.h"
 
 namespace etiss
 {
@@ -52,33 +53,28 @@ namespace plugin
 {
 
 /**
-        simple logger implementation.
-        by overriding log it would also be possible to use this as a device mounted to a certain memory address. due to
-   the function call overhead this is only suggested for testing purposes
+  simple logger implementation.
 */
-class Logger : public etiss::SystemWrapperPlugin
+class Logger : public etiss::plugin::SelectiveSysWrapper
 {
+  public:
+    struct CustomHandle
+    {
+        uint64_t addr = 0;
+        uint64_t mask = 0;
+        ETISS_System *origSys = nullptr;
+    };
+
   public:
     Logger(uint64_t addr_value, uint64_t addr_mask);
 
-    virtual ETISS_System *wrap(ETISS_CPU *cpu, ETISS_System *system); // wrap read/write redirection
-
-    virtual ETISS_System *unwrap(ETISS_CPU *cpu, ETISS_System *system); // undo wrapping
-
-    /** @brief this function writes the content of buf with length len to std::cout.
-     *        It is called by write functions if the write address is the specified
-     *        logger address.
-     * @attention if called by iread then the buf pointer is NULL
-     */
-    virtual int32_t log(bool isread, uint64_t local_addr, uint8_t *buf,
-                        unsigned len); // called whenever a write(or read) occured to logger address
+    ETISS_System getWrapInfo(ETISS_System *origSystem) final;
 
   protected:
     inline virtual std::string _getPluginName() const { return std::string("Logger"); }
 
   private:
-    uint64_t addr;
-    uint64_t mask;
+    CustomHandle customHandle_;
 };
 
 } // namespace plugin

--- a/include/etiss/IntegratedLibrary/MemMappedPeriph.h
+++ b/include/etiss/IntegratedLibrary/MemMappedPeriph.h
@@ -1,0 +1,68 @@
+
+
+#ifndef ETISS_PLUGIN_MEMMAPPEDPERIPH_H
+#define ETISS_PLUGIN_MEMMAPPEDPERIPH_H
+
+#include "etiss/IntegratedLibrary/SelectiveSysWrapper.h"
+
+namespace etiss
+{
+
+namespace plugin
+{
+
+static inline etiss_uint8 unimpl_read()
+{
+    etiss::log(etiss::WARNING, "Unimplemented MemMappedPeriph read");
+    return 0;
+}
+static inline void unimpl_write()
+{
+    etiss::log(etiss::WARNING, "Unimplemented MemMappedPeriph write");
+}
+
+/// @brief Represents a memory region that is associated with a MemMappedPeriph.
+struct MappedMemory
+{
+    uintptr_t base = 0;
+    size_t size = 0;
+};
+
+/// @brief SystemWrapperPlugin to redirect data reads and writes to custom callbacks.
+class MemMappedPeriph : public etiss::plugin::SelectiveSysWrapper
+{
+  public:
+    struct CustomHandle
+    {
+        ETISS_System *origSys = nullptr;
+        MemMappedPeriph *mmp = nullptr;
+        etiss_uint64 base = 0;
+        etiss_uint64 end = 0;
+    };
+
+  public:
+    /**
+     * @brief Defines in which memory region to map this peripheral.
+     */
+    virtual MappedMemory getMappedMem() const = 0;
+
+    virtual etiss_uint8 read8(etiss_uint64 addr) { return unimpl_read(); }
+    virtual etiss_uint16 read16(etiss_uint64 addr) { return unimpl_read(); }
+    virtual etiss_uint32 read32(etiss_uint64 addr) { return unimpl_read(); }
+    virtual etiss_uint64 read64(etiss_uint64 addr) { return unimpl_read(); }
+    virtual void write8(etiss_uint64 addr, etiss_uint8 val) { unimpl_write(); }
+    virtual void write16(etiss_uint64 addr, etiss_uint16 val) { unimpl_write(); }
+    virtual void write32(etiss_uint64 addr, etiss_uint32 val) { unimpl_write(); }
+    virtual void write64(etiss_uint64 addr, etiss_uint64 val) { unimpl_write(); }
+
+    ETISS_System getWrapInfo(ETISS_System *origSystem) final;
+
+  private:
+    CustomHandle customHandle_;
+};
+
+} // namespace plugin
+
+} // namespace etiss
+
+#endif

--- a/include/etiss/IntegratedLibrary/SelectiveSysWrapper.h
+++ b/include/etiss/IntegratedLibrary/SelectiveSysWrapper.h
@@ -1,0 +1,36 @@
+#ifndef ETISS_PLUGIN_SELECTIVESYSWRAPPER_H
+#define ETISS_PLUGIN_SELECTIVESYSWRAPPER_H
+
+#include "etiss/Plugin.h"
+
+namespace etiss
+{
+
+namespace plugin
+{
+
+/// @brief SystemWrapperPlugin that only wraps some of the System calls.
+class SelectiveSysWrapper : public etiss::SystemWrapperPlugin
+{
+  public:
+    /**
+     * @brief Defines which System functions to wrap.
+     *
+     * @details Initialize an ETISS_System struct to zero and only set the fields of the functions that this plugin
+     * should wrap. The handle field may be set to a custom data structure that will be passed to the wrapped functions
+     * as first argument.
+     *
+     * @param origSystem The System that is being wrapped. Must be stored by the plugin to fall back to the parent
+     * System.
+     */
+    virtual ETISS_System getWrapInfo(ETISS_System *origSystem) = 0;
+
+    ETISS_System *wrap(ETISS_CPU *cpu, ETISS_System *system) final;
+    ETISS_System *unwrap(ETISS_CPU *cpu, ETISS_System *system) final;
+};
+
+} // namespace plugin
+
+} // namespace etiss
+
+#endif

--- a/src/IntegratedLibrary/MemMappedPeriph.cpp
+++ b/src/IntegratedLibrary/MemMappedPeriph.cpp
@@ -1,0 +1,84 @@
+#include "etiss/IntegratedLibrary/MemMappedPeriph.h"
+#include "etiss/jit/ReturnCode.h"
+
+namespace etiss
+{
+namespace plugin
+{
+
+etiss_int32 dread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buf, etiss_uint32 len)
+{
+    auto customH = (MemMappedPeriph::CustomHandle *)handle;
+    if (addr < customH->base || addr >= customH->end)
+    {
+        return customH->origSys->dread(customH->origSys->handle, cpu, addr, buf, len);
+    }
+
+    switch (len)
+    {
+    case 1:
+        *buf = customH->mmp->read8(addr);
+        break;
+    case 2:
+        *(etiss_uint16 *)buf = customH->mmp->read16(addr);
+        break;
+    case 4:
+        *(etiss_uint32 *)buf = customH->mmp->read32(addr);
+        break;
+    case 8:
+        *(etiss_uint64 *)buf = customH->mmp->read64(addr);
+        break;
+    default:
+        etiss::log(etiss::WARNING, "Ignored access to MemMappedPeriph because of unusual size");
+    }
+
+    return ETISS_RETURNCODE_NOERROR;
+}
+
+etiss_int32 dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buf, etiss_uint32 len)
+{
+    auto customH = (MemMappedPeriph::CustomHandle *)handle;
+    if (addr < customH->base || addr >= customH->end)
+    {
+        return customH->origSys->dwrite(customH->origSys->handle, cpu, addr, buf, len);
+    }
+
+    switch (len)
+    {
+    case 1:
+        customH->mmp->write8(addr, *buf);
+        break;
+    case 2:
+        customH->mmp->write16(addr, *(etiss_uint16 *)buf);
+        break;
+    case 4:
+        customH->mmp->write32(addr, *(etiss_uint32 *)buf);
+        break;
+    case 8:
+        customH->mmp->write64(addr, *(etiss_uint64 *)buf);
+        break;
+    default:
+        etiss::log(etiss::WARNING, "Ignored access to MemMappedPeriph because of unusual size");
+    }
+
+    return ETISS_RETURNCODE_NOERROR;
+}
+
+ETISS_System MemMappedPeriph::getWrapInfo(ETISS_System *origSystem)
+{
+    customHandle_.origSys = origSystem;
+    customHandle_.mmp = this;
+
+    auto mm = getMappedMem();
+    customHandle_.base = mm.base;
+    customHandle_.end = mm.base + mm.size;
+
+    ETISS_System wrapInfo = {};
+    wrapInfo.handle = &customHandle_;
+    wrapInfo.dread = &dread;
+    wrapInfo.dwrite = &dwrite;
+    return wrapInfo;
+}
+
+} // namespace plugin
+} // namespace etiss

--- a/src/IntegratedLibrary/SelectiveSysWrapper.cpp
+++ b/src/IntegratedLibrary/SelectiveSysWrapper.cpp
@@ -1,0 +1,121 @@
+#include "etiss/IntegratedLibrary/SelectiveSysWrapper.h"
+#include "etiss/ETISS.h"
+
+namespace etiss
+{
+namespace plugin
+{
+
+struct WrapSystem
+{
+    ETISS_System sys;
+    ETISS_System *orig;
+    std::vector<void *> jitHandles;
+};
+
+ETISS_System *SelectiveSysWrapper::wrap(ETISS_CPU *cpu, ETISS_System *system)
+{
+    auto ret = new WrapSystem();
+    ret->sys.handle = system->handle;
+    ret->orig = system;
+
+    auto jit = ((CPUCore *)cpu->_etiss_private_handle_)->getJIT();
+    std::set<std::string> headers;
+    headers.insert(etiss::jitFiles());
+    std::string jitErr;
+
+    auto makeWrapper = [&](void *funcPtr, void *handle, bool isDbg, bool isSync, bool isIRead)
+    {
+        std::string funcAddr = std::to_string((uintptr_t)funcPtr);
+        std::string params, cast, call;
+        params += "void *handle";
+        cast += "void*";
+        call += "(void*)" + std::to_string((uintptr_t)handle) + "ull";
+        if (!isDbg)
+        {
+            params += ", ETISS_CPU *cpu";
+            cast += ", ETISS_CPU*";
+            call += ", cpu";
+        }
+        if (!isSync)
+        {
+            params += ", etiss_uint64 addr";
+            cast += ", etiss_uint64";
+            call += ", addr";
+            if (!isIRead)
+            {
+                params += ", etiss_uint8 *buffer";
+                cast += ", etiss_uint8*";
+                call += ", buffer";
+            }
+            params += ", etiss_uint32 length";
+            cast += ", etiss_uint32";
+            call += ", length";
+        }
+
+        std::string code = "#include \"etiss/jit/System.h\"\n";
+        code += "etiss_int32 wrapper(" + params + "){\n";
+        code += "  return ((etiss_int32 (*)(" + cast + "))" + funcAddr + ")(" + call + ");\n}\n";
+
+        void *jitHandle = jit->translate(code, headers, {}, {}, jitErr, false);
+        ret->jitHandles.push_back(jitHandle);
+        return jit->getFunction(jitHandle, "wrapper", jitErr);
+    };
+
+    ETISS_System wrapInfo = getWrapInfo(system);
+    ret->sys = *system;
+    if (wrapInfo.iread)
+    {
+        ret->sys.iread =
+            (decltype(ret->sys.iread))makeWrapper((void *)wrapInfo.iread, wrapInfo.handle, false, false, true);
+    }
+    if (wrapInfo.iwrite)
+    {
+        ret->sys.iwrite =
+            (decltype(ret->sys.iwrite))makeWrapper((void *)wrapInfo.iwrite, wrapInfo.handle, false, false, false);
+    }
+    if (wrapInfo.dread)
+    {
+        ret->sys.dread =
+            (decltype(ret->sys.dread))makeWrapper((void *)wrapInfo.dread, wrapInfo.handle, false, false, false);
+    }
+    if (wrapInfo.dwrite)
+    {
+        ret->sys.dwrite =
+            (decltype(ret->sys.dwrite))makeWrapper((void *)wrapInfo.dwrite, wrapInfo.handle, false, false, false);
+    }
+    if (wrapInfo.dbg_read)
+    {
+        ret->sys.dbg_read =
+            (decltype(ret->sys.dbg_read))makeWrapper((void *)wrapInfo.dbg_read, wrapInfo.handle, true, false, false);
+    }
+    if (wrapInfo.dbg_write)
+    {
+        ret->sys.dbg_write =
+            (decltype(ret->sys.dbg_write))makeWrapper((void *)wrapInfo.dbg_write, wrapInfo.handle, true, false, false);
+    }
+    if (wrapInfo.syncTime)
+    {
+        ret->sys.syncTime =
+            (decltype(ret->sys.syncTime))makeWrapper((void *)wrapInfo.syncTime, wrapInfo.handle, false, true, false);
+    }
+
+    return (ETISS_System *)ret;
+}
+
+ETISS_System *SelectiveSysWrapper::unwrap(ETISS_CPU *cpu, ETISS_System *system)
+{
+    auto wrapSys = (WrapSystem *)system;
+    auto jit = ((CPUCore *)cpu->_etiss_private_handle_)->getJIT();
+    for (auto h : wrapSys->jitHandles)
+    {
+        jit->free(h);
+    }
+    ETISS_System *orig = (wrapSys)->orig;
+    delete wrapSys;
+    return orig;
+}
+
+} // namespace plugin
+
+} // namespace etiss


### PR DESCRIPTION
SelectiveSysWrapper: Only wraps some of the System calls to avoid unnecessary intermediate calls.

MemMappedPeriph: Currently unused, but useful as a base for lightweight memory mapped peripherals.

The Logger plugin was changed to use the SelectiveSysWrapper, so that it only has to override the dwrite System call. This improves performance by about 10% while the Logger is active.