### PR TITLE
Code Clean-up: Move include of SimpleIni.h form ETISS.h to ETISS.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ if(NOT elfio_srcs_POPULATED)
 	FetchContent_GetProperties(elfio_srcs)
 endif()
 
+### simpleini
 FetchContent_Declare(simpleini_srcs
 	GIT_REPOSITORY https://github.com/brofield/simpleini.git
 	GIT_TAG v4.19
@@ -244,8 +245,19 @@ if(NOT simpleini_srcs_POPULATED)
 	FetchContent_Populate(simpleini_srcs)
 	FetchContent_GetProperties(simpleini_srcs)
 endif()
-
-set(ETISS_SOURCE ${ETISS_SOURCE} "${simpleini_srcs_SOURCE_DIR}/ConvertUTF.c")
+add_library(simpleini OBJECT
+    "${simpleini_srcs_SOURCE_DIR}/ConvertUTF.c"
+)
+set_target_properties(simpleini PROPERTIES
+    PUBLIC_HEADER "${simpleini_srcs_SOURCE_DIR}/SimpleIni.h;${simpleini_srcs_SOURCE_DIR}/ConvertUTF.h"
+)
+target_include_directories(simpleini PUBLIC
+    $<BUILD_INTERFACE:${simpleini_srcs_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/simpleini>
+)
+install(TARGETS simpleini
+    PUBLIC_HEADER DESTINATION include/simpleini
+)
 
 ### Doxyfile
 set(ETISS_DOX_LOCATIONS ${ETISS_DOX_LOCATIONS} ${PROJECT_BINARY_DIR}/include)
@@ -371,8 +383,8 @@ TARGET_INCLUDE_DIRECTORIES(ETISS PUBLIC
     "${PROJECT_BINARY_DIR}/include_c"
     ${INCGEN_INC_DIR}
     ${elfio_srcs_SOURCE_DIR}
-    ${simpleini_srcs_SOURCE_DIR}
 )
+TARGET_LINK_LIBRARIES(ETISS PUBLIC simpleini)
 
 GENERATE_EXPORT_HEADER(ETISS
           BASE_NAME ETISS_PLUGIN

--- a/include/etiss/ETISS.h
+++ b/include/etiss/ETISS.h
@@ -65,7 +65,6 @@
 #include "etiss/Misc.h"
 
 #include "etiss/LibraryInterface.h"
-#include "SimpleIni.h"
 
 namespace etiss
 {

--- a/src/ETISS.cpp
+++ b/src/ETISS.cpp
@@ -46,6 +46,8 @@
 #include <boost/program_options/variables_map.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include "SimpleIni.h"
+
 #if ETISS_USE_DLSYM
 #include <dlfcn.h>
 #endif

--- a/src/ETISS.cpp
+++ b/src/ETISS.cpp
@@ -1006,3 +1006,4 @@ std::string etiss::errorMessage(etiss::int32 code, CPUArch *arch)
         }
     }
 }
+


### PR DESCRIPTION
Moving include of external dependency header SimpleIni form ETISS.h to ETISS.cpp where it is actually required.
This allows external programs to use ETISS.h without re-importing SimpleIni.