### PR TITLE
fix windows build

### DIFF
--- a/include/etiss/ETISS.h
+++ b/include/etiss/ETISS.h
@@ -66,6 +66,10 @@
 
 #include "etiss/LibraryInterface.h"
 #include "SimpleIni.h"
+// SimpleIni includes windows.h which defines NOERROR, clashing with our ReturnCode.
+#ifdef NOERROR
+#undef NOERROR
+#endif
 
 namespace etiss
 {


### PR DESCRIPTION
see: https://github.com/tum-ei-eda/etiss/pull/126#issuecomment-1422913016

it seems like we had a little patch in simpleini.h that avoided to include windows.h

https://github.com/tum-ei-eda/etiss/commit/f53752f66621b07583ff64efd6d236af550b17d5#diff-46b3be838bc4b17ea1d3f87af7b24c5b5951af73dd5f08bc76dfbc4feedfdefdL3175

we now have to work around this issue after including simpleini.