### PR TITLE
update register interface of accelerators

### DIFF
--- a/examples/SW/riscv/CMakeLists.txt
+++ b/examples/SW/riscv/CMakeLists.txt
@@ -7,4 +7,8 @@ include(cmake/PulpinoTarget.cmake)
 
 ADD_DEFINITIONS(-DPULPINO_NO_GPIO)
 
-ADD_EXECUTABLE_PULPINO(riscv_example.elf main.c)
+ADD_EXECUTABLE_PULPINO(riscv_example.elf 
+							main.c 
+							./test_accelerators/qvanilla_acc.c
+							./test_accelerators/vanilla_acc.c
+					  )

--- a/examples/SW/riscv/main.c
+++ b/examples/SW/riscv/main.c
@@ -31,7 +31,7 @@ typedef struct regs
 	int32_t kw; 
 	int32_t i_zp;  // Can be negative
 	int32_t k_zp;  // Can be negative
-	int32_t control;
+	uint32_t control;
 } regs_t;
 
 

--- a/examples/SW/riscv/main.c
+++ b/examples/SW/riscv/main.c
@@ -1,7 +1,84 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+/*
+\param ifmap Pointer to input feature map data of size iw*ih*ic*sizeof(int8_t). 
+\param weights Pointer to weight data of size kh*kw*ic**oc*sizeof(int8_t). 
+\param bias_data Pointer to bias data of size oc*sizeof(int32_t). 
+\param compute Pointer to output feature map data of size iw*ih*oc*sizeof(int32_t). 
+\param oc Number of channels of output feature map. 
+\param iw Width of input feature map, ifmap. 
+\param ih Height of input feature map, ifmap. 
+\param ic Number of channels of input feature map. 
+\param kh Height of convolution kernels. 
+\param kw Width of convolution kernels.
+\param i_zp  
+\param k_zp 
+*/
+
+
+typedef struct regs 
+{
+	uint32_t ifmap;   
+	uint32_t weights;
+	uint32_t bias; 
+	uint32_t result;  
+	int32_t oc;      
+	int32_t iw;      
+	int32_t ih;      
+	int32_t ic;      
+	int32_t kh;      
+	int32_t kw; 
+	int32_t i_zp;  // Can be negative
+	int32_t k_zp;  // Can be negative
+	int32_t control;
+} regs_t;
+
+
+uint32_t qvanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, 									  int32_t* bias_data, int32_t* compute, 
+									  int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp) 
+{
+
+	regs_t *p_regs  = (regs_t *)0x70000000;  // set the base address of the peripheral, that would come form some hw ip header. 
+	p_regs->ifmap   = (uint32_t) q_vanilla_accelerator_0_i0; 
+	p_regs->weights = (uint32_t) q_vanilla_accelerator_0_i1;
+	p_regs->bias    = (uint32_t) bias_data; 
+	p_regs->result  = (uint32_t) compute;  
+	
+	p_regs->oc = oc;      
+	p_regs->iw = iw;      
+	p_regs->ih = ih;      
+	p_regs->ic = ic;      
+	p_regs->kh = kh;      
+	p_regs->kw = kw; 
+	p_regs->i_zp = i_zp;
+	p_regs->k_zp = k_zp;
+	p_regs->control = 1;  // last command, to start the operation
+
+	// MK: TODO: well, this implementation provides no status! So we don't know, if that operation was successful!
+
+    return 0;
+}
+
+
+
 int main()
 {
     printf("hello world!\n");
+
+	printf("qvanilla_accelerator test:\n");
+	
+	int8_t  i0[9] = { 1, 0, 1, 1, 0, 1, 1, 0, 1 };
+	int8_t  i1[9] = { 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+	int32_t bias_data[9] = { -1, 0, -1, 1, 0, 1, 1, 0, 1 };
+	int32_t result[9];
+	
+	qvanilla_accelerator_conv2dnchw(i0, i1, bias_data, result, 1, 3, 3, 1, 3, 3, 0, 0);
+			
+	printf("result: 0x");
+	for( int i = 0; i < sizeof(result)/sizeof(int32_t); ++i)
+	{
+		printf("%08x ", result[i]);
+	}
+	printf("\n");
 }

--- a/examples/SW/riscv/main.c
+++ b/examples/SW/riscv/main.c
@@ -1,70 +1,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-/*
-\param ifmap Pointer to input feature map data of size iw*ih*ic*sizeof(int8_t). 
-\param weights Pointer to weight data of size kh*kw*ic**oc*sizeof(int8_t). 
-\param bias_data Pointer to bias data of size oc*sizeof(int32_t). 
-\param compute Pointer to output feature map data of size iw*ih*oc*sizeof(int32_t). 
-\param oc Number of channels of output feature map. 
-\param iw Width of input feature map, ifmap. 
-\param ih Height of input feature map, ifmap. 
-\param ic Number of channels of input feature map. 
-\param kh Height of convolution kernels. 
-\param kw Width of convolution kernels.
-\param i_zp  
-\param k_zp 
-*/
+#include "./test_accelerators/qvanilla_acc.h"
+#include "./test_accelerators/vanilla_acc.h"
 
 
-typedef struct regs 
+void test_qvanilla_acc(void)
 {
-	uint32_t ifmap;   
-	uint32_t weights;
-	uint32_t bias; 
-	uint32_t result;  
-	int32_t oc;      
-	int32_t iw;      
-	int32_t ih;      
-	int32_t ic;      
-	int32_t kh;      
-	int32_t kw; 
-	int32_t i_zp;  // Can be negative
-	int32_t k_zp;  // Can be negative
-	uint32_t control;
-} regs_t;
-
-
-uint32_t qvanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, 									  int32_t* bias_data, int32_t* compute, 
-									  int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp) 
-{
-
-	regs_t *p_regs  = (regs_t *)0x70000000;  // set the base address of the peripheral, that would come form some hw ip header. 
-	p_regs->ifmap   = (uint32_t) q_vanilla_accelerator_0_i0; 
-	p_regs->weights = (uint32_t) q_vanilla_accelerator_0_i1;
-	p_regs->bias    = (uint32_t) bias_data; 
-	p_regs->result  = (uint32_t) compute;  
-	
-	p_regs->oc = oc;      
-	p_regs->iw = iw;      
-	p_regs->ih = ih;      
-	p_regs->ic = ic;      
-	p_regs->kh = kh;      
-	p_regs->kw = kw; 
-	p_regs->i_zp = i_zp;
-	p_regs->k_zp = k_zp;
-	p_regs->control = 1;  // last command, to start the operation
-
-	// MK: TODO: well, this implementation provides no status! So we don't know, if that operation was successful!
-
-    return 0;
-}
-
-
-
-int main()
-{
-    printf("hello world!\n");
 
 	printf("qvanilla_accelerator test:\n");
 	
@@ -81,4 +23,35 @@ int main()
 		printf("%08x ", result[i]);
 	}
 	printf("\n");
+}
+
+
+void test_vanilla_acc(void)
+{
+
+	printf("vanilla_accelerator test:\n");
+	
+	float  i0[9] = { 1, 0, 1, 1, 0, 1, 1, 0, 1 };
+	float  i1[9] = { 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+	float  result[9];
+	
+	vanilla_accelerator_conv2dnchw(i0, i1, result, 1, 3, 3, 1, 3, 3);
+			
+	printf("result: float:");
+	for( int i = 0; i < sizeof(result)/sizeof(int32_t); ++i)
+	{
+		printf("%f ", result[i]);
+	}
+	printf("\n");
+}
+
+
+int main()
+{
+    printf("hello world!\n");
+
+	test_qvanilla_acc();
+
+	test_vanilla_acc();
+
 }

--- a/examples/SW/riscv/test_accelerators/qvanilla_acc.c
+++ b/examples/SW/riscv/test_accelerators/qvanilla_acc.c
@@ -1,0 +1,46 @@
+
+#include "qvanilla_acc.h"
+
+
+typedef struct regs 
+{
+	uint32_t ifmap;   
+	uint32_t weights;
+	uint32_t bias; 
+	uint32_t result;  
+	int32_t oc;      
+	int32_t iw;      
+	int32_t ih;      
+	int32_t ic;      
+	int32_t kh;      
+	int32_t kw; 
+	int32_t i_zp;  // Can be negative
+	int32_t k_zp;  // Can be negative
+	uint32_t control;
+} regs_t;
+
+
+uint32_t qvanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, int32_t* bias_data, int32_t* compute, 
+									  int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp) 
+{
+
+	regs_t *p_regs  = (regs_t *)0x70000000;  // set the base address of the peripheral, that would come form some hw ip header. 
+	p_regs->ifmap   = (uint32_t) q_vanilla_accelerator_0_i0; 
+	p_regs->weights = (uint32_t) q_vanilla_accelerator_0_i1;
+	p_regs->bias    = (uint32_t) bias_data; 
+	p_regs->result  = (uint32_t) compute;  
+	
+	p_regs->oc = oc;      
+	p_regs->iw = iw;      
+	p_regs->ih = ih;      
+	p_regs->ic = ic;      
+	p_regs->kh = kh;      
+	p_regs->kw = kw; 
+	p_regs->i_zp = i_zp;
+	p_regs->k_zp = k_zp;
+	p_regs->control = 1;  // last command, to start the operation
+
+	// MK: TODO: well, this implementation provides no status! So we don't know, if that operation was successful!
+
+    return 0;
+}

--- a/examples/SW/riscv/test_accelerators/qvanilla_acc.h
+++ b/examples/SW/riscv/test_accelerators/qvanilla_acc.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+/*
+\param ifmap Pointer to input feature map data of size iw*ih*ic*sizeof(int8_t). 
+\param weights Pointer to weight data of size kh*kw*ic**oc*sizeof(int8_t). 
+\param bias_data Pointer to bias data of size oc*sizeof(int32_t). 
+\param compute Pointer to output feature map data of size iw*ih*oc*sizeof(int32_t). 
+\param oc Number of channels of output feature map. 
+\param iw Width of input feature map, ifmap. 
+\param ih Height of input feature map, ifmap. 
+\param ic Number of channels of input feature map. 
+\param kh Height of convolution kernels. 
+\param kw Width of convolution kernels.
+\param i_zp  
+\param k_zp 
+*/
+
+uint32_t qvanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, int32_t* bias_data, int32_t* compute, 
+									  int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp);

--- a/examples/SW/riscv/test_accelerators/vanilla_acc.c
+++ b/examples/SW/riscv/test_accelerators/vanilla_acc.c
@@ -1,0 +1,37 @@
+#include "vanilla_acc.h"
+
+typedef struct regs 
+{
+	uint32_t ifmap;   
+	uint32_t weights;
+	uint32_t result;  
+	int32_t oc;      
+	int32_t iw;      
+	int32_t ih;      
+	int32_t ic;      
+	int32_t kh;      
+	int32_t kw; 
+	uint32_t control;
+} regs_t;
+
+uint32_t vanilla_accelerator_conv2dnchw(float* ifmap, float* weights, float* result, int oc, int iw, int ih, int ic,
+                        int kh, int kw) 
+{
+
+	regs_t *p_regs  = (regs_t *)0x70001000;  // set the base address of the peripheral, that would come form some hw ip header. 
+	p_regs->ifmap   = (uint32_t) ifmap; 
+	p_regs->weights = (uint32_t) weights;
+	p_regs->result  = (uint32_t) result;  
+	
+	p_regs->oc = oc;      
+	p_regs->iw = iw;      
+	p_regs->ih = ih;      
+	p_regs->ic = ic;      
+	p_regs->kh = kh;      
+	p_regs->kw = kw; 
+	p_regs->control = 1;  // last command, to start the operation
+
+	// MK: TODO: well, this implementation provides no status! So we don't know, if that operation was successful!
+
+    return 0;
+}

--- a/examples/SW/riscv/test_accelerators/vanilla_acc.h
+++ b/examples/SW/riscv/test_accelerators/vanilla_acc.h
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+/*
+\param ifmap Pointer to input feature map data of size iw*ih*ic*sizeof(int8_t). 
+\param weights Pointer to weight data of size kh*kw*ic**oc*sizeof(int8_t). 
+\param bias_data Pointer to bias data of size oc*sizeof(int32_t). 
+\param compute Pointer to output feature map data of size iw*ih*oc*sizeof(int32_t). 
+\param oc Number of channels of output feature map. 
+\param iw Width of input feature map, ifmap. 
+\param ih Height of input feature map, ifmap. 
+\param ic Number of channels of input feature map. 
+\param kh Height of convolution kernels. 
+\param kw Width of convolution kernels.
+\param i_zp  
+\param k_zp 
+*/
+
+uint32_t vanilla_accelerator_conv2dnchw(float* ifmap, float* weights, float* result, int oc, int iw, int ih, int ic, int kh, int kw);

--- a/include/etiss/IntegratedLibrary/MemMappedPeriph.h
+++ b/include/etiss/IntegratedLibrary/MemMappedPeriph.h
@@ -24,7 +24,7 @@ static inline void unimpl_write()
 /// @brief Represents a memory region that is associated with a MemMappedPeriph.
 struct MappedMemory
 {
-    uintptr_t base = 0;
+    etiss_uint64 base = 0; 
     size_t size = 0;
 };
 
@@ -48,11 +48,11 @@ class MemMappedPeriph : public etiss::plugin::SelectiveSysWrapper
 
     virtual etiss_uint8 read8(etiss_uint64 addr) { return unimpl_read(); }
     virtual etiss_uint16 read16(etiss_uint64 addr) { return unimpl_read(); }
-    virtual etiss_int32 read32(etiss_uint64 addr) { return unimpl_read(); }  //I changed the return value to signed
+    virtual etiss_uint32 read32(etiss_uint64 addr) { return unimpl_read(); }
     virtual etiss_uint64 read64(etiss_uint64 addr) { return unimpl_read(); }
     virtual void write8(etiss_uint64 addr, etiss_uint8 val) { unimpl_write(); }
     virtual void write16(etiss_uint64 addr, etiss_uint16 val) { unimpl_write(); }
-    virtual void write32(etiss_uint64 addr, etiss_int32 val) { unimpl_write(); } //I changed the written value to signed
+    virtual void write32(etiss_uint64 addr, etiss_uint32 val) { unimpl_write(); }
     virtual void write64(etiss_uint64 addr, etiss_uint64 val) { unimpl_write(); }
 
     ETISS_System getWrapInfo(ETISS_System *origSystem) final;

--- a/include/etiss/IntegratedLibrary/QVanillaAccelerator.h
+++ b/include/etiss/IntegratedLibrary/QVanillaAccelerator.h
@@ -12,19 +12,23 @@ namespace plugin
 class QVanillaAccelerator: public etiss::plugin::MemMappedPeriph
 {
     public:
-        void write32(uint64_t addr, int32_t val);
 
-        int32_t read32(uint64_t addr);
+        QVanillaAccelerator(uint64_t addr=0x70000000) : regIf{}, base_addr{addr} { }
+
+        void write32(uint64_t addr, uint32_t val);
+
+        uint32 read32(uint64_t addr);
 
         MappedMemory getMappedMem() const {
             MappedMemory mm;
-            mm.base = 0x70000000;
-            mm.size = 0x34;
+            mm.base = base_addr;
+            mm.size = sizeof(RegIF);
             return mm;
         }
 
     private:
-        struct RegIF
+
+        typedef struct regs 
         {
             uint32_t ifmap;   
             uint32_t weights;
@@ -39,11 +43,17 @@ class QVanillaAccelerator: public etiss::plugin::MemMappedPeriph
             int32_t i_zp;
             int32_t k_zp;
             int32_t control;
-        };
+        } regs_t;
 
+        union RegIF
+        {
+            regs_t regs;
+            uint32_t arr[sizeof(regs_t)/sizeof(uint32_t)];
+        };
         RegIF regIf;
         
     protected:
+        uint64_t base_addr;
         std::string _getPluginName() const;
 
 };

--- a/include/etiss/IntegratedLibrary/QVanillaAccelerator.h
+++ b/include/etiss/IntegratedLibrary/QVanillaAccelerator.h
@@ -42,7 +42,7 @@ class QVanillaAccelerator: public etiss::plugin::MemMappedPeriph
             int32_t kw; 
             int32_t i_zp;
             int32_t k_zp;
-            int32_t control;
+            uint32_t control;
         } regs_t;
 
         union RegIF

--- a/include/etiss/IntegratedLibrary/VanillaAccelerator.h
+++ b/include/etiss/IntegratedLibrary/VanillaAccelerator.h
@@ -9,22 +9,27 @@ namespace etiss
 namespace plugin
 {
 
+
 class VanillaAccelerator: public etiss::plugin::MemMappedPeriph
 {
     public:
+
+        VanillaAccelerator(uint64_t addr=0x70000000) : regIf{}, base_addr{addr} {}
+
         void write32(uint64_t addr, uint32_t val);
 
-        uint32_t read32(uint64_t addr);
+        uint32 read32(uint64_t addr);
 
         MappedMemory getMappedMem() const {
             MappedMemory mm;
-            mm.base = 0x70000000;
-            mm.size = 0x28;
+            mm.base = base_addr;
+            mm.size = sizeof(RegIF);
             return mm;
         }
 
     private:
-        struct RegIF
+
+        typedef struct regs 
         {
             uint32_t ifmap;   
             uint32_t weights; 
@@ -36,11 +41,17 @@ class VanillaAccelerator: public etiss::plugin::MemMappedPeriph
             uint32_t kh;      
             uint32_t kw;  
             uint32_t control;
-        };
+        } regs_t;
 
+        union RegIF
+        {
+            regs_t regs;
+            uint32_t arr[sizeof(regs_t)/sizeof(uint32_t)];
+        };
         RegIF regIf;
         
     protected:
+        uint64_t base_addr;
         std::string _getPluginName() const;
 
 };

--- a/src/IntegratedLibrary.cpp
+++ b/src/IntegratedLibrary.cpp
@@ -113,44 +113,47 @@ extern "C"
     {
         switch (index)
         {
-        case 0:
-        {
-            /// expected option format: -rREGISTERNAME -> FILEPATH (e.g. -rR4 -> /home/you/registerErrors.txt)
-            etiss::plugin::errorInjection::BlockAccurateHandler *ret =
-                new etiss::plugin::errorInjection::BlockAccurateHandler();
-            for (auto iter = options.begin(); iter != options.end(); iter++)
+            case 0:
             {
-                if (iter->first.length() > 2 && iter->first[0] == '-' && iter->first[1] == 'r')
+                /// expected option format: -rREGISTERNAME -> FILEPATH (e.g. -rR4 -> /home/you/registerErrors.txt)
+                etiss::plugin::errorInjection::BlockAccurateHandler *ret =
+                    new etiss::plugin::errorInjection::BlockAccurateHandler();
+                for (auto iter = options.begin(); iter != options.end(); iter++)
                 {
-                    std::string regname = iter->first.substr(2);
-                    ret->parseFile(iter->second, regname);
+                    if (iter->first.length() > 2 && iter->first[0] == '-' && iter->first[1] == 'r')
+                    {
+                        std::string regname = iter->first.substr(2);
+                        ret->parseFile(iter->second, regname);
+                    }
+                    else
+                    {
+                        etiss::log(etiss::WARNING,
+                                std::string("IntegratedLibrary: failed to parse option for BlockAccurateHandler: ") +
+                                    iter->first + "->" + iter->second);
+                    }
                 }
-                else
-                {
-                    etiss::log(etiss::WARNING,
-                               std::string("IntegratedLibrary: failed to parse option for BlockAccurateHandler: ") +
-                                   iter->first + "->" + iter->second);
-                }
+                return ret;
             }
-            return ret;
-        }
-        case 1:
-            return etiss::plugin::gdb::Server::createTCPServer(options);
-        case 2:
-            return new etiss::plugin::PrintInstruction();
-        case 3:
-        {
-            etiss::Configuration cfg;
-            cfg.config() = options;
-            return new etiss::plugin::Logger(cfg.get<uint64_t>("plugin.logger.logaddr", 0x80000000),
-                                             cfg.get<uint64_t>("plugin.logger.logmask", 0xF0000000));
-        }
-            
-        case 4:
-            return new etiss::plugin::QVanillaAccelerator();
-            // return new etiss::plugin::VanillaAccelerator();
-        }
-         
+            case 1:
+                return etiss::plugin::gdb::Server::createTCPServer(options);
+            case 2:
+                return new etiss::plugin::PrintInstruction();
+            case 3:
+            {
+                etiss::Configuration cfg;
+                cfg.config() = options;
+                return new etiss::plugin::Logger(cfg.get<uint64_t>("plugin.logger.logaddr", 0x80000000),
+                                                cfg.get<uint64_t>("plugin.logger.logmask", 0xF0000000));
+            }
+                
+            case 4:
+            {
+                etiss::Configuration cfg;
+                cfg.config() = options;
+                return new etiss::plugin::QVanillaAccelerator(cfg.get<uint64_t>("plugin.QVanillaAccelerator.baseaddr", 0x70000000));
+                // return new etiss::plugin::VanillaAccelerator();
+            }
+        } 
         return 0;
     }
 

--- a/src/IntegratedLibrary.cpp
+++ b/src/IntegratedLibrary.cpp
@@ -64,7 +64,7 @@
 #include "etiss/IntegratedLibrary/errorInjection/Plugin.h"
 #include "etiss/IntegratedLibrary/gdb/GDBServer.h"
 #include "etiss/IntegratedLibrary/QVanillaAccelerator.h"
-// #include "etiss/IntegratedLibrary/VanillaAccelerator.h"
+#include "etiss/IntegratedLibrary/VanillaAccelerator.h"
 
 extern "C"
 {
@@ -76,7 +76,7 @@ extern "C"
 
     unsigned ETISSINCLUDED_countCPUArch() { return 0; }
 
-    unsigned ETISSINCLUDED_countPlugin() { return 5; }
+    unsigned ETISSINCLUDED_countPlugin() { return 6; }
 
     const char *ETISSINCLUDED_nameJIT(unsigned index) { return 0; }
 
@@ -94,11 +94,12 @@ extern "C"
             return "PrintInstruction";
         case 3:
             return "Logger";
-        
         case 4:
             return "QVanillaAccelerator";
-            // return "VanillaAccelerator";
+        case 5:
+            return "VanillaAccelerator";
         }
+        // if you add here something, update also the number returned by "ETISSINCLUDED_countPlugin" :-)
         return 0;
     }
 
@@ -111,6 +112,7 @@ extern "C"
 
     etiss::Plugin *ETISSINCLUDED_createPlugin(unsigned index, std::map<std::string, std::string> options)
     {
+        // for the index, see return of "ETISSINCLUDED_namePlugin"
         switch (index)
         {
             case 0:
@@ -145,7 +147,6 @@ extern "C"
                 return new etiss::plugin::Logger(cfg.get<uint64_t>("plugin.logger.logaddr", 0x80000000),
                                                 cfg.get<uint64_t>("plugin.logger.logmask", 0xF0000000));
             }
-                
             case 4:
             {
                 etiss::Configuration cfg;
@@ -153,6 +154,13 @@ extern "C"
                 return new etiss::plugin::QVanillaAccelerator(cfg.get<uint64_t>("plugin.QVanillaAccelerator.baseaddr", 0x70000000));
                 // return new etiss::plugin::VanillaAccelerator();
             }
+            case 5:
+            {
+                etiss::Configuration cfg;
+                cfg.config() = options;
+                return new etiss::plugin::VanillaAccelerator(cfg.get<uint64_t>("plugin.VanillaAccelerator.baseaddr", 0x70001000));
+            }
+
         } 
         return 0;
     }

--- a/src/IntegratedLibrary/QVanillaAccelerator.cpp
+++ b/src/IntegratedLibrary/QVanillaAccelerator.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "etiss/IntegratedLibrary/QVanillaAccelerator.h"
 
 namespace etiss
@@ -9,24 +10,40 @@ namespace plugin
 int conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, int32_t* bias_data, int32_t* compute,
               int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp);
 
-void QVanillaAccelerator::write32(uint64_t addr, int32_t val)
+void QVanillaAccelerator::write32(uint64_t addr, uint32_t val)
 {
-    uint64_t offset = addr - 0x70000000; 
-    *(int32_t*)((intptr_t)&regIf + offset) = val;
+    uint64_t offset = addr - base_addr; 
+    // this is the infeed: it is just also "memory", with-out the understand of a sign. it is just like a copy. 
+    size_t reg_index = offset/sizeof(uint32_t);
+    regIf.arr[reg_index] = val;
+    regs_t *p_regs = &regIf.regs;
 
     // std::cout << "adr = " << addr << std::endl;
     // std::cout << "val = " << val << std::endl;
 
-    if (offset == 0x00000030) {     //if (regIf.control == 0x00000001)
-
-        // std::cout << regIf.ifmap << ", " << regIf.weights << ", " << regIf.bias << std::endl;
-        
+    // call the "run" function if the control register is written, with a value none zero!
+    if( offset == offsetof(regs_t, control) && p_regs->control != 0UL ) 
+    {
         // copy memory from etiss buffer to own buffer
-        size_t inputSize = regIf.iw * regIf.ih * regIf.ic * sizeof(int8_t);
-        size_t filterSize = regIf.kw * regIf.kh * regIf.ic * regIf.oc * sizeof(int8_t);  
-        size_t biasSize = regIf.oc * sizeof(int32_t);       
-        size_t resultSize = regIf.iw * regIf.ih * regIf.oc * sizeof(int32_t);
-        
+
+        // std::cout << p_regs->ifmap << ", " << p_regs->weights << ", " << p_regs->bias << std::endl;
+        // MK: can the parameters be negative? if so, what can happen? 
+        size_t inputSize = p_regs->iw * p_regs->ih * p_regs->ic * sizeof(int8_t);
+        size_t filterSize = p_regs->kw * p_regs->kh * p_regs->ic * p_regs->oc * sizeof(int8_t);
+        size_t biasSize = p_regs->oc * sizeof(int32_t);
+        size_t resultSize = p_regs->iw * p_regs->ih * p_regs->oc * sizeof(int32_t);
+
+        // TODO: MK: turn output into ETISS Info/Warning via ETISS logger!!!??
+        if (inputSize == 0 || filterSize == 0 || biasSize == 0 || resultSize == 0)
+        {
+            std::cout << "Warning: QVanillaAccelerator: sizes are misconfiguered: " << std::endl;
+            std::cout << "         inputSize  : " << inputSize  << std::endl;
+            std::cout << "         filterSize : " << filterSize << std::endl;
+            std::cout << "         biasSize   : " << biasSize   << std::endl;
+            std::cout << "         resultSize : " << resultSize << std::endl;
+            std::cout << "*** QVanillaAccelerator: stop processing!!!" << std::endl;
+            return;
+        }
 
         uint8_t* input_buffer = (uint8_t*)malloc(inputSize);
         uint8_t* filter_buffer = (uint8_t*)malloc(filterSize);
@@ -37,22 +54,21 @@ void QVanillaAccelerator::write32(uint64_t addr, int32_t val)
         
         // etiss_int32 (*dread)(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length);
 
-        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, regIf.ifmap, input_buffer, inputSize); //input data  
+        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, p_regs->ifmap, input_buffer, inputSize); //input data  
         if (status != 0) 
           std::cout << "copy ifmap failed!" << std::endl;
-        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, regIf.weights, filter_buffer, filterSize); //filter data  
+        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, p_regs->weights, filter_buffer, filterSize); //filter data  
         if (status != 0) 
           std::cout << "copy weights failed!" << std::endl;
-        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, regIf.bias, bias_buffer, biasSize); //biasData 
+        status = plugin_system_->dread(plugin_system_->handle, plugin_cpu_, p_regs->bias, bias_buffer, biasSize); //biasData 
         if (status != 0) 
           std::cout << "copy bias failed!" << std::endl;
-        
 
-        conv2dnchw((int8_t*)input_buffer, (int8_t*)filter_buffer, (int32_t*)bias_buffer, (int32_t*)result_buffer, regIf.oc, regIf.iw, regIf.ih, 
-                                       regIf.ic, regIf.kh, regIf.kw, regIf.i_zp, regIf.k_zp);
-        
+        conv2dnchw((int8_t*)input_buffer, (int8_t*)filter_buffer, (int32_t*)bias_buffer, (int32_t*)result_buffer, p_regs->oc, p_regs->iw, p_regs->ih, 
+                                       p_regs->ic, p_regs->kh, p_regs->kw, p_regs->i_zp, p_regs->k_zp);
+ 
         // copy from own result buffer to etiss memory
-        plugin_system_->dwrite(plugin_system_->handle, plugin_cpu_, regIf.result, result_buffer, resultSize);
+        plugin_system_->dwrite(plugin_system_->handle, plugin_cpu_, p_regs->result, result_buffer, resultSize);
 
         // std::cout << "completed!  " << std::endl;
         //free the allocated space
@@ -65,10 +81,13 @@ void QVanillaAccelerator::write32(uint64_t addr, int32_t val)
 }
 
 
-int32_t QVanillaAccelerator::read32(uint64_t addr)
+uint32_t QVanillaAccelerator::read32(uint64_t addr)
 {
-    uint64_t offset = addr - 0x70000000;
-    int32_t val = *(int32*)((intptr_t)&regIf + offset);
+
+    uint64_t offset = addr - base_addr; 
+    size_t reg_index = offset/sizeof(uint32_t);
+    uint32_t val = regIf.arr[reg_index];
+
     // std::cout << "read" << std::endl;
     // std::cout << "adr = " << addr << std::endl;
     // std::cout << "val = " << val << std::endl;

--- a/src/IntegratedLibrary/QVanillaAccelerator.cpp
+++ b/src/IntegratedLibrary/QVanillaAccelerator.cpp
@@ -64,7 +64,7 @@ void QVanillaAccelerator::write32(uint64_t addr, uint32_t val)
         if (status != 0) 
           std::cout << "copy bias failed!" << std::endl;
 
-        conv2dnchw((int8_t*)input_buffer, (int8_t*)filter_buffer, (int32_t*)bias_buffer, (int32_t*)result_buffer, p_regs->oc, p_regs->iw, p_regs->ih, 
+        (void) conv2dnchw((int8_t*)input_buffer, (int8_t*)filter_buffer, (int32_t*)bias_buffer, (int32_t*)result_buffer, p_regs->oc, p_regs->iw, p_regs->ih, 
                                        p_regs->ic, p_regs->kh, p_regs->kw, p_regs->i_zp, p_regs->k_zp);
  
         // copy from own result buffer to etiss memory

--- a/src/bare_etiss_processor/base.ini
+++ b/src/bare_etiss_processor/base.ini
@@ -24,6 +24,8 @@ ETISS::sim_mode=0
 vp::simulation_time_us=20000000
 
 [Plugin Logger]
-
 plugin.logger.logaddr=0x80000000
 plugin.logger.logmask=0x80000000
+
+[Plugin QVanillaAccelerator]
+plugin.QVanillaAccelerator.baseaddr=0x70000000

--- a/src/bare_etiss_processor/base.ini
+++ b/src/bare_etiss_processor/base.ini
@@ -29,3 +29,6 @@ plugin.logger.logmask=0x80000000
 
 [Plugin QVanillaAccelerator]
 plugin.QVanillaAccelerator.baseaddr=0x70000000
+
+[Plugin VanillaAccelerator]
+plugin.QVanillaAccelerator.baseaddr=0x70001000


### PR DESCRIPTION
updated the register interface of the "Vanilla" and "QVanilla" accelerators, to resolve sign/unsigned issue. 
the base address of the peripherals can be controlled via ini-file
added "Vanilla" accelerator as 2nd peripheral.
added device code example to use both accelerators.

What might be good, if some error handling/completion signaling can be added in future. 
