### PR TITLE
GCCJIT: enable -Wall flag in debug mode

### DIFF
--- a/JITImpl/GCC/GCCJIT.cpp
+++ b/JITImpl/GCC/GCCJIT.cpp
@@ -113,9 +113,9 @@ void *GCCJIT::translate(std::string code, std::set<std::string> headerpaths, std
         codeFile.close();
     }
     std::stringstream ss;
-    ss << "gcc -c -std=c99 -fPIC -march=native -mtune=native -pipe "; // CHANGED -Wall eliminated
+    ss << "gcc -c -std=c99 -fPIC -march=native -mtune=native -pipe ";
     if (debug)
-        ss << "-g -O0 ";
+        ss << "-g -O0 -Wall ";
     else
         ss << "-Ofast ";
     for (std::set<std::string>::const_iterator iter = headerpaths.begin(); iter != headerpaths.end(); iter++)

--- a/JITImpl/GCC/GCCJIT.cpp
+++ b/JITImpl/GCC/GCCJIT.cpp
@@ -115,7 +115,7 @@ void *GCCJIT::translate(std::string code, std::set<std::string> headerpaths, std
     std::stringstream ss;
     ss << "gcc -c -std=c99 -fPIC -march=native -mtune=native -pipe ";
     if (debug)
-        ss << "-g -O0 -Wall ";
+        ss << "-g -O0 -Wall -Wno-unused-label ";
     else
         ss << "-Ofast ";
     for (std::set<std::string>::const_iterator iter = headerpaths.begin(); iter != headerpaths.end(); iter++)


### PR DESCRIPTION
Use `-Wall` flag to print all warnings generated by GCCJIT when `jit.debug=true` to ease debugging.