### PR TITLE
CMake: Support building ArchImpl Plugins out-of-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,7 @@ configure_file(
  )
 install(FILES
   "${PROJECT_SOURCE_DIR}/cmake/ETISSPlugin.cmake"
+  "${PROJECT_SOURCE_DIR}/cmake/RegisterJITFiles.cmake"
   "${PROJECT_BINARY_DIR}/ETISSConfig.cmake"
   "${PROJECT_BINARY_DIR}/ETISSConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)

--- a/cmake/RegisterJITFiles.cmake
+++ b/cmake/RegisterJITFiles.cmake
@@ -10,9 +10,11 @@ MACRO(RegisterJITFiles Files)
 
         # mimicing installation in build tree as well
         # NOTE: pluginexport hasn't been generated yet so will be copied later
-        if (NOT "${ExistingFile}" STREQUAL "${ETISS_BINARY_DIR}/include/etiss/pluginexport.h")
-          file(COPY "${ExistingFile}" DESTINATION "${ETISS_BINARY_DIR}/include/jit/${TargetPath}")
-        endif()
+        IF(ETISS_BINARY_DIR)
+          if (NOT "${ExistingFile}" STREQUAL "${ETISS_BINARY_DIR}/include/etiss/pluginexport.h")
+            file(COPY "${ExistingFile}" DESTINATION "${ETISS_BINARY_DIR}/include/jit/${TargetPath}")
+          endif()
+        ENDIF()
     ENDFOREACH()
 ENDMACRO()
 
@@ -20,5 +22,7 @@ MACRO(RegisterJITFileArch Arch)
     INSTALL(FILES "${CMAKE_CURRENT_LIST_DIR}/${Arch}.h" DESTINATION "include/jit/Arch/${Arch}")
 
     # mimicing installation in build tree as well
-    file(COPY "${CMAKE_CURRENT_LIST_DIR}/${Arch}.h" DESTINATION "${ETISS_BINARY_DIR}/include/jit/Arch/${Arch}")
+    IF(ETISS_BINARY_DIR)
+      file(COPY "${CMAKE_CURRENT_LIST_DIR}/${Arch}.h" DESTINATION "${ETISS_BINARY_DIR}/include/jit/Arch/${Arch}")
+    ENDIF()
 ENDMACRO()


### PR DESCRIPTION
Should resolve #156 

Documentation and Example: https://github.com/tum-ei-eda/etiss-arch-plugins