### PR TITLE
Add GDBServer Integration Tests (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
         chmod +x etiss_prebuilt/bin/bare_etiss_processor
         etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini --jit.type=${{matrix.jit_engine}}JIT
 
+    - name: Test GDBServer
+      run: |
+        ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
+
   run_benchmarks:
     runs-on: ubuntu-22.04
     needs: [build_etiss, build_examples]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ env:
 jobs:
   build_etiss:
     runs-on: ubuntu-22.04
-
     steps:
     - uses: actions/checkout@v4
       with:
@@ -44,7 +43,7 @@ jobs:
     strategy:
       matrix:
         bits: ["32", "64"]
-
+        build_type: ["Release", "Debug"]    
     steps:
     - uses: actions/checkout@v4
       with:
@@ -60,21 +59,21 @@ jobs:
 
     - name: Configure examples
       run: |
-        cmake -B examples_build_rv${{matrix.bits}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        cmake -B examples_build_rv${{matrix.bits}}_${{matrix.build_type}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
 
     - name: Build examples
       run: |
-        cmake --build examples_build_rv${{matrix.bits}} -j$(nproc)
+        cmake --build examples_build_rv${{matrix.bits}}_${{matrix.build_type}} -j$(nproc)
 
     - name: Install examples
       run: |
-        cmake --build examples_build_rv${{matrix.bits}} --target install
+        cmake --build examples_build_rv${{matrix.bits}}_${{matrix.build_type}} --target install
 
     - name: Upload prebuilt examples
       uses: actions/upload-artifact@v4
       with:
-        name: examples_prebuilt_rv${{matrix.bits}}
-        path: examples_prebuilt_rv${{matrix.bits}}
+        name: examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}
+        path: examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}
 
   run_examples:
     runs-on: ubuntu-22.04
@@ -85,6 +84,7 @@ jobs:
         bits: ["32", "64"]
         jit_engine: ["TCC", "GCC", "LLVM"]
         test_program: ["example_c", "example_cpp", "test_cases"]
+        build_type: ["Release", "Debug"]
 
     steps:
     - name: Fetch precompiled artifacts
@@ -98,7 +98,7 @@ jobs:
     - name: Run test
       run: |
         chmod +x etiss_prebuilt/bin/bare_etiss_processor
-        etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}/ini/${{matrix.test_program}}.ini --jit.type=${{matrix.jit_engine}}JIT
+        etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini --jit.type=${{matrix.jit_engine}}JIT
 
   run_benchmarks:
     runs-on: ubuntu-22.04
@@ -109,6 +109,7 @@ jobs:
         bits: ["32", "64"]
         jit_engine: ["TCC", "GCC", "LLVM"]
         run_no: [1, 2, 3, 4, 5]
+        build_type: ["Release"]
 
     steps:
     - name: Fetch precompiled artifacts
@@ -122,13 +123,13 @@ jobs:
     - name: Run benchmark
       run: |
         chmod +x etiss_prebuilt/bin/bare_etiss_processor
-        etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}/ini/dhry.ini --jit.type=${{matrix.jit_engine}}JIT --vp.stats_file_path=${{github.workspace}}/run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.run_no}}.json
+        etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/dhry.ini --jit.type=${{matrix.jit_engine}}JIT --vp.stats_file_path=${{github.workspace}}/run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.build_type}}_${{matrix.run_no}}.json
 
     - name: Save Benchmark results
       uses: actions/upload-artifact@v4
       with:
-        name: run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.run_no}}
-        path: run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.run_no}}.json
+        name: run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.build_type}}_${{matrix.run_no}}
+        path: run_${{matrix.jit_engine}}_${{matrix.bits}}_${{matrix.build_type}}_${{matrix.run_no}}.json
 
   merge_benchmark_results:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,39 @@ jobs:
         name: etiss_prebuilt
         path: etiss_prebuilt
 
-  build_examples:
+  setup_toolchain:
     runs-on: ubuntu-22.04
 
     strategy:
       matrix:
+        gcc_version: ["13.2.0-2"]
+
+    steps:
+    - name: Download Cached GCC Binaries
+      id: cache-gcc
+      uses: actions/cache@v4
+      with:
+        path: riscv_tc/
+        key: gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
+        restore-keys: |
+          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}
+       
+    - name: Install cross compiler
+      if: steps.cache-gcc.outputs.cache-hit != 'true'
+      run: |
+        wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v${{ matrix.gcc_version }}/xpack-riscv-none-elf-gcc-${{ matrix.gcc_version }}-linux-x64.tar.gz
+        tar xf xpack-riscv-none-elf-gcc-${{ matrix.gcc_version }}-linux-x64.tar.gz
+        mv xpack-riscv-none-elf-gcc-${{ matrix.gcc_version }} riscv_tc
+
+  build_examples:
+    runs-on: ubuntu-22.04
+    needs: [setup_toolchain]
+    
+    strategy:
+      matrix:
         bits: ["32", "64"]
         build_type: ["Release", "Debug"]
+        gcc_version: ["13.2.0-2"]
         
     steps:
     - uses: actions/checkout@v4
@@ -52,11 +78,16 @@ jobs:
         path: examples_source
         submodules: true
 
-    - name: Install cross compiler
-      run: |
-        wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz
-        tar xf xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz
-        mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv_tc
+    - name: Download Cached GCC Binaries
+      if: success()
+      id: cache-gcc
+      uses: actions/cache/restore@v4
+      with:
+        path: riscv_tc/
+        key: gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
+        restore-keys: |
+          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
+          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}
 
     - name: Configure examples
       run: |
@@ -88,8 +119,6 @@ jobs:
         build_type: ["Release", "Debug"]
 
     steps:
-    - uses: actions/checkout@v4
-    
     - name: Fetch precompiled artifacts
       uses: actions/download-artifact@v4
 
@@ -106,6 +135,46 @@ jobs:
     - name: Test GDBServer
       run: |
         ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
+
+  test_gdbserver:
+    runs-on: ubuntu-22.04
+    needs: [build_etiss, build_examples, run_examples]
+
+    strategy:
+      matrix:
+        bits: ["32", "64"]
+        jit_engine: ["TCC", "GCC", "LLVM"]
+        test_program: ["example_c", "example_cpp", "test_cases"]
+        build_type: ["Debug"]
+        gcc_version: ["13.2.0-2"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Fetch precompiled artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libboost-filesystem-dev libboost-program-options-dev libllvm11
+
+    - name: Download Cached GCC Binaries
+      if: success()
+      id: cache-gcc
+      uses: actions/cache/restore@v4
+      with:
+        path: riscv_tc/
+        key: gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
+        restore-keys: |
+          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
+          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}
+
+    - name: Test GDBServer
+      run: |
+        chmod +x etiss_prebuilt/bin/bare_etiss_processor
+        ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
+
 
   run_benchmarks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: riscv_tc/
-        key: gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}-${{ github.sha }}
-        restore-keys: |
-          gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}
+        key: gcc-binaries-${{ runner.os }}-${{ matrix.gcc_version }}
        
     - name: Install cross compiler
       if: steps.cache-gcc.outputs.cache-hit != 'true'
@@ -79,7 +77,6 @@ jobs:
         submodules: true
 
     - name: Download Cached GCC Binaries
-      if: success()
       id: cache-gcc
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,6 @@ jobs:
         chmod +x etiss_prebuilt/bin/bare_etiss_processor
         etiss_prebuilt/bin/bare_etiss_processor -iexamples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini --jit.type=${{matrix.jit_engine}}JIT
 
-    - name: Test GDBServer
-      run: |
-        ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
-
   test_gdbserver:
     runs-on: ubuntu-22.04
     needs: [build_etiss, build_examples, run_examples]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       matrix:
         bits: ["32", "64"]
-        build_type: ["Release", "Debug"]    
+        build_type: ["Release", "Debug"]
+        
     steps:
     - uses: actions/checkout@v4
       with:
@@ -87,6 +88,8 @@ jobs:
         build_type: ["Release", "Debug"]
 
     steps:
+    - uses: actions/checkout@v4
+    
     - name: Fetch precompiled artifacts
       uses: actions/download-artifact@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Configure examples
       run: |
-        cmake -B examples_build_rv${{matrix.bits}}_${{matrix.build_type}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        cmake -B examples_build_rv${{matrix.bits}}_${{matrix.build_type}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DTVM=OFF -DTFLM=OFF
 
     - name: Build examples
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
     - name: Test GDBServer
       run: |
         chmod +x etiss_prebuilt/bin/bare_etiss_processor
-        ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
+        ETISS=$(pwd)/etiss_prebuilt/bin/bare_etiss_processor RISCV_GDB=$(pwd)/riscv_tc/bin/riscv-none-elf-gdb timeout 360s ./script/test_gdbserver.sh examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/ini/${{matrix.test_program}}.ini examples_prebuilt_rv${{matrix.bits}}_${{matrix.build_type}}/bin/${{matrix.test_program}} 2001 ${{matrix.jit_engine}}
 
 
   run_benchmarks:

--- a/script/gdbserver_test.cmd
+++ b/script/gdbserver_test.cmd
@@ -12,3 +12,4 @@ info registers
 i r x0
 i r zero
 i r pc
+delete

--- a/script/gdbserver_test.cmd
+++ b/script/gdbserver_test.cmd
@@ -1,0 +1,14 @@
+target remote :2001
+bt
+info registers
+break main
+break _exit
+continue
+bt
+info registers
+continue
+bt
+info registers
+i r x0
+i r zero
+i r pc

--- a/script/test_gdbserver.sh
+++ b/script/test_gdbserver.sh
@@ -12,13 +12,8 @@ export ELF=${2:-./examples_prebuilt_rv32/bin/hello_world}
 export PORT=${3:-2001}
 export JIT=${4:-TCC}
 TIMEOUT_SEC=${5:-180}
-echo qqq
+
 $ETISS -i$INI --jit.type=${JIT}JIT -pgdbserver --plugin.gdbserver.port=$PORT 2>&1 > etiss_output.log &
-# tee_pid=$!
-# echo www
-# sleep 0.1  # give the processes a moment to start
-# ETISS_PID=$(pgrep -P $tee_pid)
-# echo "PID of tee: $tee_pid"
 ETISS_PID=$!
 echo ETISS_PID=$ETISS_PID
 
@@ -61,9 +56,9 @@ fi
 
 grep -q "Remote communication error" gdb_output.log && GDB_CRASH=1 || GDB_CRASH=0
 
-elif [[ $TIMEOUT_EXIT -ne 0 ]]
+if [[ $GDB_CRASH -ne 0 ]]
 then
-    echo "GDB Session crashed!"
+    echo "GDB connection lost!"
     exit 1
 fi
 

--- a/script/test_gdbserver.sh
+++ b/script/test_gdbserver.sh
@@ -12,10 +12,16 @@ export ELF=${2:-./examples_prebuilt_rv32/bin/hello_world}
 export PORT=${3:-2001}
 export JIT=${4:-TCC}
 TIMEOUT_SEC=${5:-180}
-
-$ETISS -i$INI --jit.type=${JIT}JIT -pgdbserver --plugin.gdbserver.port=$PORT &
+echo qqq
+$ETISS -i$INI --jit.type=${JIT}JIT -pgdbserver --plugin.gdbserver.port=$PORT 2>&1 > etiss_output.log &
+# tee_pid=$!
+# echo www
+# sleep 0.1  # give the processes a moment to start
+# ETISS_PID=$(pgrep -P $tee_pid)
+# echo "PID of tee: $tee_pid"
 ETISS_PID=$!
 echo ETISS_PID=$ETISS_PID
+
 
 # Ensure ETISS is killed on failure
 cleanup() {
@@ -34,25 +40,15 @@ sleep 1
 
 # echo "Ready"
 
-# Avoid non-zero exit code of GDB if etiss disconnects after simulation
-
 run_gdb_session() {
-    $RISCV_GDB -q -nx -batch -x $SCRIPT_DIR/gdbserver_test.cmd "$ELF" -ex "continue" && OK=1 || OK=0
-    echo "OK=$OK"
-    if [[ $OK -eq 0 ]]
-    then
-        echo "GDB reported non-zero exit!"
-        exit 1
-    else
-        echo "GDB finished successfully!"
-    fi
+    # Avoid non-zero exit code of GDB if etiss disconnects after simulation
+    $RISCV_GDB -q -nx -batch -x $SCRIPT_DIR/gdbserver_test.cmd "$ELF" -ex "continue" || true
 }
 export -f run_gdb_session
 
-#set -o pipefail
 timeout $TIMEOUT_SEC bash -c run_gdb_session 2>&1 | tee gdb_output.log
 TIMEOUT_EXIT=$?
-#set +o pipefail
+
 
 if [[ $TIMEOUT_EXIT -eq 124 ]]
 then
@@ -64,9 +60,13 @@ then
     exit 1
 fi
 
+echo C
+
 # read -n 1
 
 # echo "Done"
+
+echo "Waiting for etiss to close... (PID=$ETISS_PID)"
 
 wait $ETISS_PID
 ETISS_EXIT=$?
@@ -90,5 +90,8 @@ for re in "${checks[@]}"; do
         echo "check ok: $re"
     fi
 done
+
+echo "Cleaning up..."  # TODO: use temp workdir?
+rm gdb_output.log
 
 echo "✅ test passed"

--- a/script/test_gdbserver.sh
+++ b/script/test_gdbserver.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+RISCV_GDB=${RISCV_GDB:-riscv-none-elf-gdb}
+ETISS=${ETISS:-bare_etiss_processor}
+
+INI=${1:-./examples_prebuilt_rv32/ini/hello_world.ini}
+ELF=${2:-./examples_prebuilt_rv32/bin/hello_world}
+PORT=${3:-2001}
+JIT=${4:-TCC}
+
+$ETISS -i$INI --jit.type=${JIT}JIT -pgdbserver --plugin.gdbserver.port=$PORT &
+ETISS_PID=$!
+echo ETISS_PID=$ETISS_PID
+
+# Ensure ETISS is killed on failure
+cleanup() {
+    echo "Cleaning up..."
+    kill $ETISS_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait until gdbserver socket is ready
+for i in {1..10}; do
+    if nc -z localhost $PORT; then break; fi
+    sleep 0.2
+done
+
+# echo "Ready"
+
+# Avoid non-xero exit code of GDB if etiss disconnects after simulation
+($RISCV_GDB -q -nx -batch -x $SCRIPT_DIR/gdbserver_test.cmd "$ELF" -ex "continue" || true) 2>&1 | tee gdb_output.log
+
+# read -n 1
+
+# echo "Done"
+
+wait $ETISS_PID
+ETISS_EXIT=$?
+
+echo ETISS_EXIT=$ETISS_EXIT
+
+checks=(
+  '^x0[[:space:]]+0x0[[:space:]]+0($|[[:space:]])'
+  '^zero[[:space:]]+0x0[[:space:]]+0($|[[:space:]])'
+  '^pc[[:space:]]+0x[0-9a-fA-F]+[[:space:]]+0x[0-9a-fA-F]+[[:space:]]+<[^>]+>'
+  'Breakpoint 1'
+  'Breakpoint 2'
+  'Remote connection closed'
+)
+
+for re in "${checks[@]}"; do
+    if ! grep -qE "$re" gdb_output.log; then
+        echo "❌ Check failed for regex: $re"
+        exit 1
+    else
+        echo "check ok: $re"
+    fi
+done
+
+echo "✅ test passed"

--- a/script/test_gdbserver.sh
+++ b/script/test_gdbserver.sh
@@ -33,10 +33,10 @@ trap cleanup EXIT
 # Wait until gdbserver socket is ready
 for i in {1..10}; do
     if nc -z localhost $PORT; then break; fi
-    sleep 0.2
+    sleep 1
 done
 
-sleep 1
+sleep 3
 
 # echo "Ready"
 
@@ -49,7 +49,6 @@ export -f run_gdb_session
 timeout $TIMEOUT_SEC bash -c run_gdb_session 2>&1 | tee gdb_output.log
 TIMEOUT_EXIT=$?
 
-
 if [[ $TIMEOUT_EXIT -eq 124 ]]
 then
     echo "GDB Session timed out!"
@@ -60,7 +59,13 @@ then
     exit 1
 fi
 
-echo C
+grep -q "Remote communication error" gdb_output.log && GDB_CRASH=1 || GDB_CRASH=0
+
+elif [[ $TIMEOUT_EXIT -ne 0 ]]
+then
+    echo "GDB Session crashed!"
+    exit 1
+fi
 
 # read -n 1
 
@@ -92,6 +97,7 @@ for re in "${checks[@]}"; do
 done
 
 echo "Cleaning up..."  # TODO: use temp workdir?
+rm etiss_output.log
 rm gdb_output.log
 
 echo "✅ test passed"


### PR DESCRIPTION
In preparation to merging #161, I wanted to add some gdbserver-related smoke tests to our ci.

Before this can be merged a few TODOs need to be resolved:
- [ ] Support building examples using Clang/LLVM
- [ ] Support debugging with lldb
- [x] Improve `script/gdbserver_test.cmd` and regular expressions.

In the future we might want to add tests for other Plugins such as `PrintInstruction` or dbusAccess.csv.