### PR TITLE
ArchImpl/RV{32,64}IMACFD: re-generate (with improved slice literals)

### DIFF
--- a/ArchImpl/RV32IMACFD/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFD/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+# Generated on Tue, 16 Sep 2025 12:56:33 +0200.
 #
 # This file contains the CMake build info for the RV32IMACFD core architecture.
 

--- a/ArchImpl/RV32IMACFD/RV32IMACFD.h
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the registers for the RV32IMACFD core architecture.
  */

--- a/ArchImpl/RV32IMACFD/RV32IMACFDArch.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDArch.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture class for the RV32IMACFD core architecture.
  */

--- a/ArchImpl/RV32IMACFD/RV32IMACFDArch.h
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture class for the RV32IMACFD core architecture.
  */

--- a/ArchImpl/RV32IMACFD/RV32IMACFDArchLib.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the library interface for the RV32IMACFD core architecture.
  */

--- a/ArchImpl/RV32IMACFD/RV32IMACFDArchSpecificImp.h
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDArchSpecificImp.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture specific header for the RV32IMACFD
  * core architecture.
@@ -54,6 +54,7 @@ protected:
 		*((RV32IMACFD*)parent_.structure_)->X[gprid_] = (etiss_uint32) val;
 	}
 };
+
 
 class pcField_RV32IMACFD : public etiss::VirtualStruct::Field{
 public:

--- a/ArchImpl/RV32IMACFD/RV32IMACFDFuncs.c
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the function implementations for the RV32IMACFD core architecture.
  */
@@ -25,7 +25,7 @@ etiss_coverage_count(1, 277);
 etiss_coverage_count(1, 258);
 if (rm == 7ULL) { // conditional
 etiss_coverage_count(3, 261, 259, 260);
-rm = ((((((RV32IMACFD*)cpu)->FCSR) >> (5ULL)) & 7ULL)) & 0x7;
+rm = ((((((RV32IMACFD*)cpu)->FCSR) >> (5ULL)) & 0x7ULL)) & 0x7ULL;
 etiss_coverage_count(6, 267, 262, 266, 263, 264, 265);
 } // conditional
 etiss_coverage_count(1, 268);
@@ -171,7 +171,7 @@ etiss_coverage_count(1, 459);
 if (csr == 769LL) { // conditional
 etiss_coverage_count(2, 462, 460);
 etiss_coverage_count(1, 478);
-return (((1ULL) << 30) | ((((*((RV32IMACFD*)cpu)->CSR[769LL]) >> (0LL)) & 1073741823ULL)));
+return (((1ULL) << 30) | (((*((RV32IMACFD*)cpu)->CSR[769LL]) & 0x3fffffffULL)));
 etiss_coverage_count(4, 477, 476, 471, 475);
 } // conditional
 etiss_coverage_count(1, 482);
@@ -392,7 +392,7 @@ s = RV32IMACFD_set_field(s, 2LL, 0LL);
 etiss_coverage_count(5, 839, 834, 838, 835, 837);
 RV32IMACFD_csr_write(cpu, system, plugin_pointers, 256LL, s);
 etiss_coverage_count(2, 842, 841);
-((RV32IMACFD*)cpu)->PRIV = (1LL) & 0x7;
+((RV32IMACFD*)cpu)->PRIV = (1LL) & 0x7ULL;
 etiss_coverage_count(2, 845, 843);
 } // block
 } // conditional
@@ -417,7 +417,7 @@ s = RV32IMACFD_set_field(s, 8LL, 0LL);
 etiss_coverage_count(5, 908, 903, 907, 904, 906);
 RV32IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);
 etiss_coverage_count(2, 911, 910);
-((RV32IMACFD*)cpu)->PRIV = (3LL) & 0x7;
+((RV32IMACFD*)cpu)->PRIV = (3LL) & 0x7ULL;
 etiss_coverage_count(2, 914, 912);
 } // block
 } // conditional

--- a/ArchImpl/RV32IMACFD/RV32IMACFDFuncs.h
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDFuncs.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the function prototypes for the RV32IMACFD core architecture.
  */
@@ -16,7 +16,6 @@ extern "C" {
 #include "etiss/jit/System.h"
 #include "etiss/jit/ReturnCode.h"
 #include "etiss/jit/Coverage.h"
-
 
 void leave(etiss_int32 priv_lvl);
 

--- a/ArchImpl/RV32IMACFD/RV32IMACFDGDBCore.h
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDGDBCore.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the GDBCore adapter for the RV32IMACFD core architecture.
  *

--- a/ArchImpl/RV32IMACFD/RV32IMACFDInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFDInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFD core architecture.
@@ -1098,7 +1098,7 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "etiss_coverage_count(1, 5612);\n";
 cp.code() += "{ // block\n";
-cp.code() += "etiss_uint64 res = ((((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 1ULL)) << 63) | ((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) >> (0LL)) & 9223372036854775807ULL)));\n";
+cp.code() += "etiss_uint64 res = ((((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 0x1ULL)) << 63) | (((((RV32IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) & 0x7fffffffffffffffULL)));\n";
 cp.code() += "etiss_coverage_count(12, 5590, 5589, 5582, 5579, 5578, 5580, 5581, 5588, 5585, 5584, 5586, 5587);\n";
 cp.code() += "((RV32IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = res;\n";
 cp.code() += "etiss_coverage_count(4, 5599, 5597, 5596, 5598);\n";
@@ -1179,7 +1179,7 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "etiss_coverage_count(1, 5650);\n";
 cp.code() += "{ // block\n";
-cp.code() += "etiss_uint64 res = (((~((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 1ULL))) << 63) | ((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) >> (0LL)) & 9223372036854775807ULL)));\n";
+cp.code() += "etiss_uint64 res = (((~((((((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 0x1ULL))) << 63) | (((((RV32IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) & 0x7fffffffffffffffULL)));\n";
 cp.code() += "etiss_coverage_count(13, 5628, 5627, 5620, 5619, 5616, 5615, 5617, 5618, 5626, 5623, 5622, 5624, 5625);\n";
 cp.code() += "((RV32IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = res;\n";
 cp.code() += "etiss_coverage_count(4, 5637, 5635, 5634, 5636);\n";

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFD core architecture.
@@ -1185,7 +1185,7 @@ cp.code() += "etiss_uint32 frs1 = unbox_s(((RV32IMACFD*)cpu)->F[" + std::to_stri
 cp.code() += "etiss_coverage_count(4, 4130, 4129, 4128, 4127);\n";
 cp.code() += "etiss_uint32 frs2 = unbox_s(((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]);\n";
 cp.code() += "etiss_coverage_count(4, 4136, 4135, 4134, 4133);\n";
-cp.code() += "etiss_uint32 res = ((((((frs2) >> (31ULL)) & 1ULL)) << 31) | ((((frs1) >> (0LL)) & 2147483647ULL)));\n";
+cp.code() += "etiss_uint32 res = ((((((frs2) >> (31ULL)) & 0x1ULL)) << 31) | (((frs1) & 0x7fffffffULL)));\n";
 cp.code() += "etiss_coverage_count(10, 4147, 4146, 4141, 4138, 4139, 4140, 4145, 4142, 4143, 4144);\n";
 cp.code() += "((RV32IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = -4294967296LL | (etiss_uint64)(res);\n";
 cp.code() += "etiss_coverage_count(6, 4160, 4150, 4149, 4159, 4158, 4156);\n";
@@ -1275,7 +1275,7 @@ cp.code() += "etiss_uint32 frs1 = unbox_s(((RV32IMACFD*)cpu)->F[" + std::to_stri
 cp.code() += "etiss_coverage_count(4, 4190, 4189, 4188, 4187);\n";
 cp.code() += "etiss_uint32 frs2 = unbox_s(((RV32IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]);\n";
 cp.code() += "etiss_coverage_count(4, 4196, 4195, 4194, 4193);\n";
-cp.code() += "etiss_uint32 res = (((~((((frs2) >> (31ULL)) & 1ULL))) << 31) | ((((frs1) >> (0LL)) & 2147483647ULL)));\n";
+cp.code() += "etiss_uint32 res = (((~((((frs2) >> (31ULL)) & 0x1ULL))) << 31) | (((frs1) & 0x7fffffffULL)));\n";
 cp.code() += "etiss_coverage_count(11, 4208, 4207, 4202, 4201, 4198, 4199, 4200, 4206, 4203, 4204, 4205);\n";
 cp.code() += "((RV32IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = -4294967296LL | (etiss_uint64)(res);\n";
 cp.code() += "etiss_coverage_count(6, 4221, 4211, 4210, 4220, 4219, 4217);\n";

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFD core architecture.
@@ -152,7 +152,7 @@ cp.code() += "s = RV32IMACFD_set_field(s, 6144LL, (RV32IMACFD_extension_enabled(
 cp.code() += "etiss_coverage_count(7, 2318, 2309, 2317, 2310, 2316, 2313, 2312);\n";
 cp.code() += "RV32IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);\n";
 cp.code() += "etiss_coverage_count(2, 2321, 2320);\n";
-cp.code() += "((RV32IMACFD*)cpu)->PRIV = (prev_prv) & 0x7;\n";
+cp.code() += "((RV32IMACFD*)cpu)->PRIV = (prev_prv) & 0x7ULL;\n";
 cp.code() += "etiss_coverage_count(3, 2324, 2322, 2323);\n";
 cp.code() += "} // block\n";
 } // block
@@ -315,7 +315,7 @@ cp.code() += "s = RV32IMACFD_set_field(s, 256LL, 0LL);\n";
 cp.code() += "etiss_coverage_count(4, 6408, 6403, 6407, 6404);\n";
 cp.code() += "RV32IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);\n";
 cp.code() += "etiss_coverage_count(2, 6411, 6410);\n";
-cp.code() += "((RV32IMACFD*)cpu)->PRIV = (prev_prv) & 0x7;\n";
+cp.code() += "((RV32IMACFD*)cpu)->PRIV = (prev_prv) & 0x7ULL;\n";
 cp.code() += "etiss_coverage_count(3, 6414, 6412, 6413);\n";
 cp.code() += "} // block\n";
 } // block

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV32IMACFD/RV32IMACFD_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFD/RV32IMACFD_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/CMakeLists.txt
+++ b/ArchImpl/RV64IMACFD/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+# Generated on Tue, 16 Sep 2025 12:56:33 +0200.
 #
 # This file contains the CMake build info for the RV64IMACFD core architecture.
 

--- a/ArchImpl/RV64IMACFD/RV64IMACFD.h
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the registers for the RV64IMACFD core architecture.
  */

--- a/ArchImpl/RV64IMACFD/RV64IMACFDArch.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDArch.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture class for the RV64IMACFD core architecture.
  */

--- a/ArchImpl/RV64IMACFD/RV64IMACFDArch.h
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture class for the RV64IMACFD core architecture.
  */

--- a/ArchImpl/RV64IMACFD/RV64IMACFDArchLib.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the library interface for the RV64IMACFD core architecture.
  */

--- a/ArchImpl/RV64IMACFD/RV64IMACFDArchSpecificImp.h
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDArchSpecificImp.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the architecture specific header for the RV64IMACFD
  * core architecture.
@@ -54,6 +54,7 @@ protected:
 		*((RV64IMACFD*)parent_.structure_)->X[gprid_] = (etiss_uint64) val;
 	}
 };
+
 
 class pcField_RV64IMACFD : public etiss::VirtualStruct::Field{
 public:

--- a/ArchImpl/RV64IMACFD/RV64IMACFDFuncs.c
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the function implementations for the RV64IMACFD core architecture.
  */
@@ -25,7 +25,7 @@ etiss_coverage_count(1, 277);
 etiss_coverage_count(1, 258);
 if (rm == 7ULL) { // conditional
 etiss_coverage_count(3, 261, 259, 260);
-rm = ((((((RV64IMACFD*)cpu)->FCSR) >> (5ULL)) & 7ULL)) & 0x7;
+rm = ((((((RV64IMACFD*)cpu)->FCSR) >> (5ULL)) & 0x7ULL)) & 0x7ULL;
 etiss_coverage_count(6, 267, 262, 266, 263, 264, 265);
 } // conditional
 etiss_coverage_count(1, 268);
@@ -171,7 +171,7 @@ etiss_coverage_count(1, 459);
 if (csr == 769LL) { // conditional
 etiss_coverage_count(2, 462, 460);
 etiss_coverage_count(1, 478);
-return (((2ULL) << 62) | ((((*((RV64IMACFD*)cpu)->CSR[769LL]) >> (0LL)) & 4611686018427387903ULL)));
+return (((2ULL) << 62) | (((*((RV64IMACFD*)cpu)->CSR[769LL]) & 0x3fffffffffffffffULL)));
 etiss_coverage_count(4, 477, 476, 471, 475);
 } // conditional
 etiss_coverage_count(1, 482);
@@ -392,7 +392,7 @@ s = RV64IMACFD_set_field(s, 2LL, 0LL);
 etiss_coverage_count(5, 839, 834, 838, 835, 837);
 RV64IMACFD_csr_write(cpu, system, plugin_pointers, 256LL, s);
 etiss_coverage_count(2, 842, 841);
-((RV64IMACFD*)cpu)->PRIV = (1LL) & 0x7;
+((RV64IMACFD*)cpu)->PRIV = (1LL) & 0x7ULL;
 etiss_coverage_count(2, 845, 843);
 } // block
 } // conditional
@@ -417,7 +417,7 @@ s = RV64IMACFD_set_field(s, 8LL, 0LL);
 etiss_coverage_count(5, 908, 903, 907, 904, 906);
 RV64IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);
 etiss_coverage_count(2, 911, 910);
-((RV64IMACFD*)cpu)->PRIV = (3LL) & 0x7;
+((RV64IMACFD*)cpu)->PRIV = (3LL) & 0x7ULL;
 etiss_coverage_count(2, 914, 912);
 } // block
 } // conditional

--- a/ArchImpl/RV64IMACFD/RV64IMACFDFuncs.h
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDFuncs.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the function prototypes for the RV64IMACFD core architecture.
  */
@@ -16,7 +16,6 @@ extern "C" {
 #include "etiss/jit/System.h"
 #include "etiss/jit/ReturnCode.h"
 #include "etiss/jit/Coverage.h"
-
 
 void leave(etiss_int32 priv_lvl);
 

--- a/ArchImpl/RV64IMACFD/RV64IMACFDGDBCore.h
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDGDBCore.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the GDBCore adapter for the RV64IMACFD core architecture.
  *

--- a/ArchImpl/RV64IMACFD/RV64IMACFDInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFDInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32AInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32DCInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32DInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV64IMACFD core architecture.
@@ -1098,7 +1098,7 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "etiss_coverage_count(1, 5612);\n";
 cp.code() += "{ // block\n";
-cp.code() += "etiss_uint64 res = ((((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 1ULL)) << 63) | ((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) >> (0LL)) & 9223372036854775807ULL)));\n";
+cp.code() += "etiss_uint64 res = ((((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 0x1ULL)) << 63) | (((((RV64IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) & 0x7fffffffffffffffULL)));\n";
 cp.code() += "etiss_coverage_count(12, 5590, 5589, 5582, 5579, 5578, 5580, 5581, 5588, 5585, 5584, 5586, 5587);\n";
 cp.code() += "((RV64IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = res;\n";
 cp.code() += "etiss_coverage_count(4, 5599, 5597, 5596, 5598);\n";
@@ -1179,7 +1179,7 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "etiss_coverage_count(1, 5650);\n";
 cp.code() += "{ // block\n";
-cp.code() += "etiss_uint64 res = (((~((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 1ULL))) << 63) | ((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) >> (0LL)) & 9223372036854775807ULL)));\n";
+cp.code() += "etiss_uint64 res = (((~((((((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]) >> (63ULL)) & 0x1ULL))) << 63) | (((((RV64IMACFD*)cpu)->F[" + std::to_string(rs1) + "ULL]) & 0x7fffffffffffffffULL)));\n";
 cp.code() += "etiss_coverage_count(13, 5628, 5627, 5620, 5619, 5616, 5615, 5617, 5618, 5626, 5623, 5622, 5624, 5625);\n";
 cp.code() += "((RV64IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = res;\n";
 cp.code() += "etiss_coverage_count(4, 5637, 5635, 5634, 5636);\n";

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32FInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV64IMACFD core architecture.
@@ -1185,7 +1185,7 @@ cp.code() += "etiss_uint32 frs1 = unbox_s(((RV64IMACFD*)cpu)->F[" + std::to_stri
 cp.code() += "etiss_coverage_count(4, 4130, 4129, 4128, 4127);\n";
 cp.code() += "etiss_uint32 frs2 = unbox_s(((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]);\n";
 cp.code() += "etiss_coverage_count(4, 4136, 4135, 4134, 4133);\n";
-cp.code() += "etiss_uint32 res = ((((((frs2) >> (31ULL)) & 1ULL)) << 31) | ((((frs1) >> (0LL)) & 2147483647ULL)));\n";
+cp.code() += "etiss_uint32 res = ((((((frs2) >> (31ULL)) & 0x1ULL)) << 31) | (((frs1) & 0x7fffffffULL)));\n";
 cp.code() += "etiss_coverage_count(10, 4147, 4146, 4141, 4138, 4139, 4140, 4145, 4142, 4143, 4144);\n";
 cp.code() += "((RV64IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = -4294967296LL | (etiss_uint64)(res);\n";
 cp.code() += "etiss_coverage_count(6, 4160, 4150, 4149, 4159, 4158, 4156);\n";
@@ -1275,7 +1275,7 @@ cp.code() += "etiss_uint32 frs1 = unbox_s(((RV64IMACFD*)cpu)->F[" + std::to_stri
 cp.code() += "etiss_coverage_count(4, 4190, 4189, 4188, 4187);\n";
 cp.code() += "etiss_uint32 frs2 = unbox_s(((RV64IMACFD*)cpu)->F[" + std::to_string(rs2) + "ULL]);\n";
 cp.code() += "etiss_coverage_count(4, 4196, 4195, 4194, 4193);\n";
-cp.code() += "etiss_uint32 res = (((~((((frs2) >> (31ULL)) & 1ULL))) << 31) | ((((frs1) >> (0LL)) & 2147483647ULL)));\n";
+cp.code() += "etiss_uint32 res = (((~((((frs2) >> (31ULL)) & 0x1ULL))) << 31) | (((frs1) & 0x7fffffffULL)));\n";
 cp.code() += "etiss_coverage_count(11, 4208, 4207, 4202, 4201, 4198, 4199, 4200, 4206, 4203, 4204, 4205);\n";
 cp.code() += "((RV64IMACFD*)cpu)->F[" + std::to_string(rd) + "ULL] = -4294967296LL | (etiss_uint64)(res);\n";
 cp.code() += "etiss_coverage_count(6, 4221, 4211, 4210, 4220, 4219, 4217);\n";

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32ICInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32IInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV32MInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64AInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64A
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64DInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64D
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64FInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64F
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64ICInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64IC
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64IInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64I
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_RV64MInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_RV64MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the RV64M
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_ZifenceiInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_csrInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_retInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV64IMACFD core architecture.
@@ -152,7 +152,7 @@ cp.code() += "s = RV64IMACFD_set_field(s, 6144LL, (RV64IMACFD_extension_enabled(
 cp.code() += "etiss_coverage_count(7, 2318, 2309, 2317, 2310, 2316, 2313, 2312);\n";
 cp.code() += "RV64IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);\n";
 cp.code() += "etiss_coverage_count(2, 2321, 2320);\n";
-cp.code() += "((RV64IMACFD*)cpu)->PRIV = (prev_prv) & 0x7;\n";
+cp.code() += "((RV64IMACFD*)cpu)->PRIV = (prev_prv) & 0x7ULL;\n";
 cp.code() += "etiss_coverage_count(3, 2324, 2322, 2323);\n";
 cp.code() += "} // block\n";
 } // block
@@ -315,7 +315,7 @@ cp.code() += "s = RV64IMACFD_set_field(s, 256LL, 0LL);\n";
 cp.code() += "etiss_coverage_count(4, 6408, 6403, 6407, 6404);\n";
 cp.code() += "RV64IMACFD_csr_write(cpu, system, plugin_pointers, 768LL, s);\n";
 cp.code() += "etiss_coverage_count(2, 6411, 6410);\n";
-cp.code() += "((RV64IMACFD*)cpu)->PRIV = (prev_prv) & 0x7;\n";
+cp.code() += "((RV64IMACFD*)cpu)->PRIV = (prev_prv) & 0x7ULL;\n";
 cp.code() += "etiss_coverage_count(3, 6414, 6412, 6413);\n";
 cp.code() += "} // block\n";
 } // block

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rva64Instr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rva64Instr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_rva64
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rvaInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rvmInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_rvmInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_rvm
  * instruction set for the RV64IMACFD core architecture.

--- a/ArchImpl/RV64IMACFD/RV64IMACFD_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV64IMACFD/RV64IMACFD_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Thu, 24 Oct 2024 10:16:12 +0200.
+ * Generated on Tue, 16 Sep 2025 12:56:33 +0200.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV64IMACFD core architecture.


### PR DESCRIPTION
Changes:
- Use hex for mask literals
- Optimize trivial slices `X[upper:lower]` where `lower = 0` to skip one zero-distance right-shift