### PR TITLE
CI: Add Lint Action

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,32 @@
+name: Style Checks
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  clang-format:
+    name: Formatting Check (C/C++)
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install build dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y libboost-filesystem-dev libboost-program-options-dev \
+          llvm-11-dev libclang-11-dev clang-11
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Run CMake to generate compilation database
+      run: |
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - uses: cpp-linter/cpp-linter-action@v2
+      id: linter
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        style: 'file'  # Use .clang-format config file
+        tidy-checks: '' # Use .clang-tidy config file
+        # only 'update' a single comment in a pull request's thread.
+        thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+        database: 'build'
+        step-summary: true

--- a/src/ETISS.cpp
+++ b/src/ETISS.cpp
@@ -59,6 +59,7 @@
 
 using namespace etiss;
 
+
 std::string etiss_defaultjit_;
 
 std::list<std::shared_ptr<etiss::LibraryInterface>> etiss_libraries_;


### PR DESCRIPTION
C/C++ Linting only for now. CMake can follow later.

I went with a less intrusive approach:
- Only changed files are checked
- Linter problems are highlighted/annotated in the Patch, PR Comments are added automatically.
- CI job always succeeds, PRs can still be merged, even if linter is unhappy.

Instead of forcing the style guide on all files at once. This way we can clean up file-by-file as soon as one PR touches them.

From what I have seen so far, running `clang-format` locally, most of the issues are just whitespace or line-length related, hence relatively easy fixes, which can be fixed and applied by running `clang-format -i path/to/file` manually.

Fixes #3 