### PR TITLE
Fix/jitverify

### DIFF
--- a/src/CPUCore.cpp
+++ b/src/CPUCore.cpp
@@ -295,12 +295,13 @@ static bool verifyJITSizeOf(std::string structname, etiss::int32 expected_size, 
         return false;
     // generate code
     std::string error;
-    std::string code = std::string(prefix + "\n#include \"etiss/jit/CPU.h\"\n#include "
-                                            "\"etiss/jit/System.h\"\n#include \"etiss/jit/ReturnCode.h\"\n "
-                                            "#include \"etiss/jit/types.h\"\n#include "
-                                            "\"etiss/jit/fpu/softfloat.h\"\n etiss_int32 get_size(){ return "
-                                            "sizeof(") +
-                       structname + ");}";
+    std::string code = std::string(prefix + R"V0G0N(
+#include "etiss/jit/CPU.h"
+#include "etiss/jit/System.h"
+#include "etiss/jit/ReturnCode.h"
+#include "etiss/jit/types.h"
+etiss_int32 get_size() { return sizeof()V0G0N" +
+                                   structname + "); };");
 
     std::set<std::string> headers;
     headers.insert(etiss::jitFiles());

--- a/src/CPUCore.cpp
+++ b/src/CPUCore.cpp
@@ -296,11 +296,6 @@ static bool verifyJITSizeOf(std::string structname, etiss::int32 expected_size, 
     // generate code
     std::string error;
     std::string code = std::string(prefix + R"V0G0N(
-#include "etiss/jit/Coverage.h"
-#include "etiss/jit/libCSRCounters.h"
-#include "etiss/jit/libresources.h"
-#include "etiss/jit/libsemihost.h"
-#include "etiss/jit/libsoftfloat.h"
 #include "etiss/jit/CPU.h"
 #include "etiss/jit/System.h"
 #include "etiss/jit/ReturnCode.h"

--- a/src/CPUCore.cpp
+++ b/src/CPUCore.cpp
@@ -296,6 +296,11 @@ static bool verifyJITSizeOf(std::string structname, etiss::int32 expected_size, 
     // generate code
     std::string error;
     std::string code = std::string(prefix + R"V0G0N(
+#include "etiss/jit/Coverage.h"
+#include "etiss/jit/libCSRCounters.h"
+#include "etiss/jit/libresources.h"
+#include "etiss/jit/libsemihost.h"
+#include "etiss/jit/libsoftfloat.h"
 #include "etiss/jit/CPU.h"
 #include "etiss/jit/System.h"
 #include "etiss/jit/ReturnCode.h"


### PR DESCRIPTION
partial solution to #158 

- [x] The fix is to remove non-existent `#include etiss/jit/fpu/softfloat.h` from the source code string.
- [ ] ETISS CI does not run with `jit.verify=true`, should it?
