### PR TITLE
src/SimpleMemSystem.cpp: add missing hex (0x) prefix for length

### DIFF
--- a/src/SimpleMemSystem.cpp
+++ b/src/SimpleMemSystem.cpp
@@ -420,7 +420,7 @@ void access_error(ETISS_CPU *cpu, etiss::uint64 addr, etiss::uint32 len, std::st
     std::stringstream ss;
 
     ss << error << ", PC = 0x" << std::hex << std::setw(8) << std::setfill('0') << pc << ", address 0x" << std::hex
-       << std::setw(8) << std::setfill('0') << addr << ", length " << len;
+       << std::setw(8) << std::setfill('0') << addr << ", length 0x" << len;
 
     etiss::log(verbosity, ss.str());
 }


### PR DESCRIPTION
At other places in that file the prefix was already used:
-  `memMsg << "The memory segment is allocated uninitialized with length 0x" << std::hex << size_ << " !";`

For consistency we should print the length either
- in decimal (no prefix) or
- in hex (with `0x` prefix)

Let me know what you prefer...