### PR TITLE
Cmdline Improvements

### DIFF
--- a/src/ETISS.cpp
+++ b/src/ETISS.cpp
@@ -766,7 +766,7 @@ void etiss_initialize(const std::vector<std::string> &args, bool forced = false)
             if (vm.count("ini"))
             {
                 auto files = vm["ini"].as<std::vector<std::string>>();
-                for (auto const& f : files)
+                for (auto const &f : files)
                 {
                     etiss_loadIni(f);
                 }


### PR DESCRIPTION
See #186 

- [x] Allow space between flag and ini filename: `-i file` 
- [x] Support long `--ini` flag 
- [x] Drop custom parser/handler
