### PR TITLE
Enable CCache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
         path: examples_source
         submodules: true
 
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        max-size: 2G
+        key: ccache-examples-${{ matrix.build_type }}-rv${{ matrix.bits }}
+        variant: sccache
+
     - name: Install cross compiler
       run: |
         wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz
@@ -76,7 +83,7 @@ jobs:
 
     - name: Configure examples
       run: |
-        cmake -B examples_build_rv${{matrix.bits}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        cmake -B examples_build_rv${{matrix.bits}} -S examples_source -DCMAKE_TOOLCHAIN_FILE=rv${{matrix.bits}}gc-toolchain.cmake -DRISCV_TOOLCHAIN_BASENAME=riscv-none-elf -DRISCV_TOOLCHAIN_PREFIX=$GITHUB_WORKSPACE/riscv_tc -DCMAKE_INSTALL_PREFIX=examples_prebuilt_rv${{matrix.bits}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     - name: Build examples
       run: |


### PR DESCRIPTION
Fixes #217 

## Results

#### Reducing required time for `build_etiss` CI job (assuming no changes) 

```
full job: 2m33s -> 1m6s
CMake build step only: 1m31s -> 15s
```


#### Reducing required time for `build_examples` CI job (assuming no changes)

```
full job: 4m41s -> 45s
Build examples step only: 4m19s -> 14s
```


#### Also reduced the CI matrix for `run_benchmarks` from 30 jobs to 12 jobs. (The benchmark results aren't used anyways...)

#### For full CI Workflow "Build ETISS and run smoke tests" (assuming no changes) 

```
before: 7m 58s
after: 3m36s
diff: 4m22s faster (rel. ~55%)
```

The jobs `run_benchmarks` (~1.5min) and `run_examples` (~1min) are now the dominant ones. Dropping GCCJIT would help here, but I would like to run the all supported JITs in CI.