### PR TITLE
hotfix/ETISS not building with newer (GCC>13) (#221)

### DIFF
--- a/include/etiss/Memory.h
+++ b/include/etiss/Memory.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <cstdint>
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/include/etiss/mm/PTEFormat.h
+++ b/include/etiss/mm/PTEFormat.h
@@ -11,6 +11,8 @@
 #include <memory>
 #include <string>
 
+#include <cstdint>
+
 namespace etiss
 {
 namespace mm

--- a/src/mm/PTE.cpp
+++ b/src/mm/PTE.cpp
@@ -42,7 +42,6 @@ void PTE::Update(uint64_t new_pte)
     }
 
     ppn_val_ = new_pte >> bit_field.second;
-    ;
     pte_val_ = new_pte;
 }
 


### PR DESCRIPTION
Fix #221 
* add missing <cstdint> include to allow build with gcc>13