### PR TITLE
LLVMJIT: check for existance of libclangBasic.{a,so} in selected LLVM

### DIFF
--- a/JITImpl/LLVM/CMakeLists.txt
+++ b/JITImpl/LLVM/CMakeLists.txt
@@ -26,22 +26,30 @@ else()
     message(STATUS "[${PROJECT_NAME}] Found LLVM ${LLVM_PACKAGE_VERSION} at ${LLVM_DIR}")
     string(REGEX MATCH "^[0-9]+" LLVM_VERSION_MAJOR "${LLVM_PACKAGE_VERSION}")
     math(EXPR LLVM_VERSION_MAJOR_NEXT "${LLVM_VERSION_MAJOR} + 1" OUTPUT_FORMAT DECIMAL)
- 
-    if(NOT Clang_FOUND) # 1st try only in relation to found LLVM
-        find_package(Clang CONFIG NO_DEFAULT_PATH PATHS "${LLVM_DIR}/../clang" "${LLVM_DIR}")
-    endif()
-    if(NOT Clang_FOUND) # 2nd try with system and default paths
-        find_package(Clang CONFIG)
-    endif()
     if(NOT Clang_FOUND)
-        message(STATUS "[${PROJECT_NAME}] Did not find matching Clang... Skipping target.")
-    else()
-        message(STATUS "[${PROJECT_NAME}] Found Clang ${Clang_PACKAGE_VERSION} at ${Clang_DIR}")
-
-        add_compile_definitions(LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR})
-        if(LLVM_VERSION_MAJOR GREATER 15 AND CMAKE_CXX_STANDARD LESS 17)
-            message(FATAL_ERROR "LLVM_VERSION_MAJOR[${LLVM_VERSION_MAJOR}] requires c++std>=17! Is ${CMAKE_CXX_STANDARD}")
+      if(EXISTS "${LLVM_INSTALL_PREFIX}/lib/libclangBasic.a" OR EXISTS "${LLVM_INSTALL_PREFIX}/lib/libclangBasic.so")
+        find_package(Clang CONFIG PATHS "${LLVM_INSTALL_PREFIX}" NO_DEFAULT_PATH)
+        if(NOT Clang_FOUND) # 1st try only in relation to found LLVM
+            find_package(Clang CONFIG NO_DEFAULT_PATH PATHS "${LLVM_DIR}/../clang" "${LLVM_DIR}")
         endif()
+        if(NOT Clang_FOUND) # 2nd try with system and default paths
+            find_package(Clang CONFIG)
+        endif()
+        if(NOT Clang_FOUND)
+            message(STATUS "[${PROJECT_NAME}] Did not find matching Clang... Skipping target.")
+        else()
+            message(STATUS "[${PROJECT_NAME}] Found Clang ${Clang_PACKAGE_VERSION} at ${Clang_DIR}")
+
+            add_compile_definitions(LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR})
+            if(LLVM_VERSION_MAJOR GREATER 15 AND CMAKE_CXX_STANDARD LESS 17)
+                message(FATAL_ERROR "LLVM_VERSION_MAJOR[${LLVM_VERSION_MAJOR}] requires c++std>=17! Is ${CMAKE_CXX_STANDARD}")
+            endif()
+        endif()
+      else()
+        message(STATUS
+          "[${PROJECT_NAME}] LLVM found but built without Clang support. Skipping target."
+        )
+      endif()
     endif()
 endif()
 


### PR DESCRIPTION
Fixes the following error which can occur if a LLVM & Clang installation is found, but the development-specific files shipped by `libclang-14-dev` are missing:

```
-- [LLVMJIT] Found LLVM 14.0.0 at /usr/lib/llvm-14/cmake CMake Error at /usr/lib/llvm-14/lib/cmake/clang/ClangTargets.cmake:750 (message): The imported target "clangBasic" references the file
 "/usr/lib/llvm-14/lib/libclangBasic.a"
but this file does not exist. Possible reasons include:
• The file was deleted, renamed, or moved to another location.
• An install or uninstall procedure did not complete successfully.
• The installation package was faulty and contained
"/usr/lib/llvm-14/lib/cmake/clang/ClangTargets.cmake"
but not all the files it references.
Call Stack (most recent call first): /usr/lib/cmake/clang-14/ClangConfig.cmake:19 (include) JITImpl/LLVM/CMakeLists.txt:31 (find_package)
```

Because this error is thrown by the LLVM/Clang cmake files and not ETISS and cmake has no `try/catch` syntax this error is difficult to avoid.

My solution, which checks for the existance of the missing file before `find_package(Clang)` is called, is a workaround, yes. Feel free to propose a better fix...

@JoGei 